### PR TITLE
Apiary Blueprint adapter requires already plain json object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/adapters/apiary-blueprint-adapter.coffee
+++ b/src/adapters/apiary-blueprint-adapter.coffee
@@ -17,7 +17,7 @@ applymarkdownHtml = (obj, targetHtmlProperty) ->
 apiaryAstToApplicationAst = (ast) ->
   return null unless ast
 
-  plainJsObject = applymarkdownHtml(ast.toJSON(), 'htmlDescription')
+  plainJsObject = applymarkdownHtml(ast, 'htmlDescription')
 
   for section, sectionKey in plainJsObject.sections or [] when section.resources?.length
     for resource, resourceKey in section.resources

--- a/test/transformation-test.coffee
+++ b/test/transformation-test.coffee
@@ -13,7 +13,7 @@ parseApiaryBlueprint = (source, cb) ->
   catch err
     err = adapter.transformError(source, err)
     return cb(err)
-  cb(null, adapter.transformAst(ast), [])
+  cb(null, adapter.transformAst(ast.toJSON()), [])
 
 
 parseApiBlueprint = (source, cb) ->


### PR DESCRIPTION
Main reason for this is that I want to transform result from parsing service and the result is already plain json.
