### PR TITLE
Exposing Markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/metamorphoses.coffee
+++ b/src/metamorphoses.coffee
@@ -2,6 +2,7 @@
 typer = require('media-typer')
 
 blueprintApi = require('./blueprint-api')
+markdown = require('./adapters/markdown')
 apiBlueprintAdapter = require('./adapters/api-blueprint-adapter')
 apiaryBlueprintAdapter = require('./adapters/apiary-blueprint-adapter')
 
@@ -31,8 +32,14 @@ createAdapter = (mimeType) ->
 
 
 module.exports = {
+  # Blueprint API (aka Application AST)
   blueprintApi
+
+  # Adapters
   createAdapter
   apiBlueprintAdapter
   apiaryBlueprintAdapter
+
+  # Markdown rendering
+  markdown
 }


### PR DESCRIPTION
We need this in the Core Application in order to remove Fury.js from dependencies.
