### PR TITLE
Fixes default value for URI templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -21,13 +21,9 @@ getUriParameters = (hrefVariables) ->
     memberContentValue = memberContent.get('value')
     type = memberContentValue.get('element').value()
 
-    defaultValue = ''
+    defaultValue = memberContentValue.get('attributes.default', '').value().toString()
     exampleValue = ''
     values = []
-
-    if (memberContentValue.has('attributes.default').value())
-      defaultValue = memberContentValue.get('attributes.default')
-        .first().content().value().toString()
 
     memberContentValueContent = memberContentValue.content()
 

--- a/test/getUriParameters-test.coffee
+++ b/test/getUriParameters-test.coffee
@@ -66,12 +66,7 @@ describe('Transformation • Refract • getUriParameters' , ->
                 'value': {
                   'element': 'enum',
                   'attributes': {
-                    'default': [
-                      {
-                        'element': 'number',
-                        'content': 2
-                      }
-                    ]
+                    'default': 1
                   },
                   'content': [
                     {
@@ -98,7 +93,7 @@ describe('Transformation • Refract • getUriParameters' , ->
             'description': '',
             'type': 'enum',
             'required': false,
-            'default': '2',
+            'default': '1',
             'example': '',
             'values': [
                 {


### PR DESCRIPTION
We supposed that value of default will be:

```
'attributes': {
  'default': [
    {
      'element': 'number',
      'content': 1
    }
  ]
}
```

but it is:

```
'attributes': {
  'default': 1
}
```

In spec can be found: https://github.com/refractproject/refract-spec/blob/master/namespaces/data-structure-namespace.md#default-value
