### PR TITLE
Fix payload data structures

### DIFF
--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -57,7 +57,7 @@ module.exports = (resourceElement) ->
       httpRequestBody = _(httpRequest).messageBodies().first()
       httpRequestBodySchemas = _(httpRequest).messageBodySchemas().first()
       httpRequestDescription = getDescription(httpRequest)
-      httpRequestBodyDataStructures = _.dataStructures(httpRequestBody)
+      httpRequestBodyDataStructures = _.dataStructures(httpRequest)
 
       if _.isEmpty(httpRequestBodyDataStructures)
         requestAttributes = undefined
@@ -68,7 +68,7 @@ module.exports = (resourceElement) ->
       httpResponseBody = _(httpResponse).messageBodies().first()
       httpResponseBodySchemas = _(httpResponse).messageBodySchemas().first()
       httpResponseDescription = getDescription(httpResponse)
-      httpResponseBodyDataStructures = _.dataStructures(httpResponseBody)
+      httpResponseBodyDataStructures = _.dataStructures(httpResponse)
 
       if _.isEmpty(httpResponseBodyDataStructures)
         responseAttributes = undefined

--- a/test/fixtures/refract-parse-result-payload-data-structures.json
+++ b/test/fixtures/refract-parse-result-payload-data-structures.json
@@ -1,0 +1,219 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ]
+      },
+      "attributes": {},
+      "content": [
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "href": "/test"
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": "POST"
+                      },
+                      "content": [
+                        {
+                          "element": "dataStructure",
+                          "meta": {},
+                          "attributes": {},
+                          "content": {
+                            "element": "object",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              {
+                                "element": "member",
+                                "meta": {
+                                  "description": "Updated name of the pet"
+                                },
+                                "attributes": {},
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": "name"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": ""
+                                  }
+                                }
+                              },
+                              {
+                                "element": "member",
+                                "meta": {
+                                  "description": "Updated status of the pet"
+                                },
+                                "attributes": {},
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": "status"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": ""
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {
+                        "statusCode": "200"
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "meta": {},
+                          "attributes": {},
+                          "content": "No response was specified"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "meta": {},
+                          "attributes": {},
+                          "content": {
+                            "element": "object",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              {
+                                "element": "member",
+                                "meta": {
+                                  "description": "Updated name of the pet"
+                                },
+                                "attributes": {},
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": "name"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": ""
+                                  }
+                                }
+                              },
+                              {
+                                "element": "member",
+                                "meta": {
+                                  "description": "Updated status of the pet"
+                                },
+                                "attributes": {},
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": "status"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "meta": {},
+                                    "attributes": {},
+                                    "content": ""
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/refract-parse-result-x-values.json
+++ b/test/fixtures/refract-parse-result-x-values.json
@@ -1,4 +1,3 @@
-
 {
   "element": "parseResult",
   "meta": {},

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -375,6 +375,26 @@ describe('Transformations • Refract', ->
       )
     )
 
+    describe('HTTP Payload Data Structures', ->
+      applicationAst = null
+
+      before(->
+        applicationAst = convertToApplicationAst(
+          require('./fixtures/refract-parse-result-payload-data-structures.json')
+        )
+      )
+
+      it('Data Structure is present for HTTP Requests', ->
+        dataStructureElement = applicationAst.sections[0].resources[0].requests[0].attributes[0].element
+        assert.strictEqual(dataStructureElement, 'dataStructure')
+      )
+
+      it('Data Structure is present for HTTP Responses', ->
+        dataStructureElement = applicationAst.sections[0].resources[0].responses[0].attributes[0].element
+        assert.strictEqual(dataStructureElement, 'dataStructure')
+      )
+    )
+
     describe('Redundant requests', ->
       applicationAst = null
 


### PR DESCRIPTION
Data structures are found in the HTTP Request and HTTP Response
elements rather than in the message bodies.

https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md#http-message-payload-element

This commit changes this to look in the request and response.
