### PR TITLE
Fix handling of ‘x-summary’ and ‘x-description’

### DIFF
--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -9,7 +9,29 @@ module.exports = (resourceElement) ->
 
   resourceDescription = getDescription(resourceElement)
 
-  _.transitions(resourceElement).forEach((transitionElement) ->
+  transitions = _.transitions(resourceElement)
+
+  # If a resources doesn't have any transitions, create a very minimal
+  # resource (URI, URI Template, Name, Description and Attributes).
+  if transitions.length is 0
+    attributes = _.dataStructures(resourceElement)
+    attributes = undefined if _.isEmpty(attributes)
+
+    return [
+      new blueprintApi.Resource({
+        url: _.chain(resourceElement).get('attributes.href', '').contentOrValue().value()
+        uriTemplate: _.chain(resourceElement).get('attributes.href', '').contentOrValue().value()
+        name: _.chain(resourceElement).get('meta.title', '').contentOrValue().value()
+
+        description: resourceDescription.raw
+        htmlDescription: resourceDescription.html
+
+        attributes
+        resolvedAttributes: attributes
+      })
+    ]
+
+  transitions.forEach((transitionElement) ->
     description = getDescription(transitionElement)
 
     resourceParameters = getUriParameters(_.get(resourceElement, 'attributes.hrefVariables'))

--- a/test/fixtures/refract-parse-result-x-summary.json
+++ b/test/fixtures/refract-parse-result-x-summary.json
@@ -1,0 +1,44 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "foo"
+      },
+      "attributes": {},
+      "content": [
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "href": "/test"
+          },
+          "content": [
+            {
+              "element": "copy",
+              "meta": {},
+              "attributes": {},
+              "content": "I am a description"
+            }
+          ]
+        },
+        {
+          "element": "resource",
+          "meta": {
+            "title": "I am a summary"
+          },
+          "attributes": {
+            "href": "/test2"
+          },
+          "content": []
+        }
+      ]
+    }
+  ]
+}

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -421,6 +421,42 @@ describe('Transformations • Refract', ->
       it('Has the correct number of resources', ->
         assert.strictEqual(applicationAst.sections[0].resources.length, 2)
       )
+
+      it('First resource has the correct URL and URI Template', ->
+        assert.strictEqual(
+          applicationAst.sections[0].resources[0].url,
+          '/test'
+        )
+        assert.strictEqual(
+          applicationAst.sections[0].resources[0].uriTemplate,
+          '/test'
+        )
+      )
+
+      it('First resource has the correct description', ->
+        assert.strictEqual(
+          applicationAst.sections[0].resources[0].description,
+          'I am a description'
+        )
+      )
+
+      it('Second resource has the correct URL and URI Template', ->
+        assert.strictEqual(
+          applicationAst.sections[0].resources[1].url,
+          '/test2'
+        )
+        assert.strictEqual(
+          applicationAst.sections[0].resources[1].uriTemplate,
+          '/test2'
+        )
+      )
+
+      it('Second resource has the correct name', ->
+        assert.strictEqual(
+          applicationAst.sections[0].resources[1].name,
+          'I am a summary'
+        )
+      )
     )
   )
 )

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -408,5 +408,19 @@ describe('Transformations • Refract', ->
         assert.strictEqual(applicationAst.sections[0].resources[0].requests.length, 1)
       )
     )
+
+    describe('‘x-summary’ and ‘x-description’', ->
+      applicationAst = null
+
+      before(->
+        applicationAst = convertToApplicationAst(
+          require('./fixtures/refract-parse-result-x-summary.json')
+        )
+      )
+
+      it('Has the correct number of resources', ->
+        assert.strictEqual(applicationAst.sections[0].resources.length, 2)
+      )
+    )
   )
 )


### PR DESCRIPTION
<a href="https://trello.com/c/9QLiVdL0/17-fix-handling-x-summary-and-x-description-in-metamorphoses-and-in-apiary"><img src="https:&#x2F;&#x2F;github.trello.services&#x2F;images&#x2F;trello-icon.png" width="12" height="12"> Fix handling ‘x-summary’ and ‘x-description’ in Metamorphoses and in Apiary</a>

---
