### PR TITLE
Fix refract transformer attributes structure

### DIFF
--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -15,7 +15,7 @@ module.exports = (resourceElement) ->
   # resource (URI, URI Template, Name, Description and Attributes).
   if transitions.length is 0
     attributes = _.dataStructures(resourceElement)
-    attributes = undefined if _.isEmpty(attributes)
+    attributes = if _.isEmpty(attributes) then undefined else attributes[0]
 
     return [
       new blueprintApi.Resource({
@@ -38,7 +38,7 @@ module.exports = (resourceElement) ->
     actionParameters = getUriParameters(_.get(transitionElement, 'attributes.hrefVariables'))
 
     attributes = _.dataStructures(resourceElement)
-    attributes = undefined if _.isEmpty(attributes)
+    attributes = if _.isEmpty(attributes) then undefined else attributes[0]
 
     # Resource
     #
@@ -84,7 +84,7 @@ module.exports = (resourceElement) ->
       if _.isEmpty(httpRequestBodyDataStructures)
         requestAttributes = undefined
       else
-        requestAttributes = httpRequestBodyDataStructures
+        requestAttributes = httpRequestBodyDataStructures[0]
 
       httpResponse  = _(httpTransaction).httpResponses().first()
       httpResponseBody = _(httpResponse).messageBodies().first()
@@ -95,7 +95,7 @@ module.exports = (resourceElement) ->
       if _.isEmpty(httpResponseBodyDataStructures)
         responseAttributes = undefined
       else
-        responseAttributes = httpResponseBodyDataStructures
+        responseAttributes = httpResponseBodyDataStructures[0]
 
       # In refract just here we have method and href
       resource.method = _.chain(httpRequest).get('attributes.method', '').contentOrValue().value()

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -385,12 +385,12 @@ describe('Transformations • Refract', ->
       )
 
       it('Data Structure is present for HTTP Requests', ->
-        dataStructureElement = applicationAst.sections[0].resources[0].requests[0].attributes[0].element
+        dataStructureElement = applicationAst.sections[0].resources[0].requests[0].attributes.element
         assert.strictEqual(dataStructureElement, 'dataStructure')
       )
 
       it('Data Structure is present for HTTP Responses', ->
-        dataStructureElement = applicationAst.sections[0].resources[0].responses[0].attributes[0].element
+        dataStructureElement = applicationAst.sections[0].resources[0].responses[0].attributes.element
         assert.strictEqual(dataStructureElement, 'dataStructure')
       )
     )

--- a/test/transformation-test.coffee
+++ b/test/transformation-test.coffee
@@ -62,7 +62,7 @@ describe('Transformations', ->
       'ast',
       'refract'
     ].forEach((type) ->
-      context("Prased by protagonist as `#{type}`", ->
+      context("Parsed by protagonist as `#{type}`", ->
         describe('When I send in simple blueprint', ->
           ast = undefined
           before((done) ->
@@ -163,6 +163,43 @@ describe('Transformations', ->
             # temporary hack before new protagonist with fix for from classes array in messageBody will be relased
             if type isnt 'refract'
               assert.equal(ast.sections[0].resources[0].responses[0].body, 'Hello World')
+          )
+        )
+
+        describe('When I send a blueprint with attributes', ->
+          ast = undefined
+          before((done) ->
+            code = '''VERSION: 2
+                  # API Name
+                  ## Resource [/foo]
+                  ### Get a foo [GET]
+                  + Response 200
+                      + Attributes
+                          + status: ok
+                  '''
+            parseApiBlueprint(code, type, (err, newAst) ->
+              ast = newAst
+              done(err)
+            )
+          )
+
+          it('Contains a resource with an attributes object', ->
+            assert.deepEqual(ast.sections[0].resources[0].responses[0].attributes,
+              element: 'dataStructure'
+              content: [
+                element: 'object'
+                content: [
+                  element: 'member'
+                  content:
+                    key:
+                      element: 'string'
+                      content: 'status'
+                    value:
+                      element: 'string'
+                      content: 'ok'
+                ]
+              ]
+            )
           )
         )
       )


### PR DESCRIPTION
This fixes a subtle but important difference between the `ApiBlueprintAdapter` and the `RefractAdapter` in how they output attributes, which was causing Attributes Kit to fail to render when given Swagger `formData` parameters, which the parser converts to the Refract data structure namespace (aka MSON).

``` js
// Output before the change
"attributes": [
      {
        "element": "dataStructure",
        "meta": {},
        "attributes": {},
        "content": { ... }
      }
]

// Output after the change, and the output of the ApiBlueprintAdapter
"attributes": {
    "element": "dataStructure",
    "meta": {},
    "attributes": {},
    "content": { ... }
}
```

I've added a small test to confirm this works as expected by comparing the output from the two adapters.

cc @Baggz 
