### PR TITLE
Use transition-level URI templates when available to include all params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -37,7 +37,8 @@ module.exports = (resourceElement) ->
     resourceParameters = getUriParameters(_.get(resourceElement, 'attributes.hrefVariables'))
     actionParameters = getUriParameters(_.get(transitionElement, 'attributes.hrefVariables'))
 
-    attributes = _.dataStructures(resourceElement)
+    attributes = _.dataStructures(transitionElement)
+    attributes = if _.isEmpty(attributes) then _.dataStructures(resourceElement) else attributes[0]
     attributes = if _.isEmpty(attributes) then undefined else attributes[0]
 
     # Resource
@@ -46,8 +47,8 @@ module.exports = (resourceElement) ->
     # * Dtto, `actionUriTemplate`
     resource = new blueprintApi.Resource({
       # TODO: `url` should contain a possible HOST suffix.
-      url: _.chain(resourceElement).get('attributes.href', '').contentOrValue().value()
-      uriTemplate: _.chain(resourceElement).get('attributes.href', '').contentOrValue().value()
+      url: _.chain(transitionElement).get('attributes.href', _.get(resourceElement, 'attributes.href')).contentOrValue().value()
+      uriTemplate: _.chain(transitionElement).get('attributes.href', _.get(resourceElement, 'attributes.href')).contentOrValue().value()
 
       name: _.chain(resourceElement).get('meta.title', '').contentOrValue().value()
 

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -292,6 +292,10 @@ describe('Transformations • Refract', ->
         resource = ast.sections[0].resources[0]
       )
 
+      it('URI template contains all parameters', ->
+        assert.equal(resource.uriTemplate, '/test/{id}{?search,arg}')
+      )
+
       it('resource have three paramters', ->
         assert.equal(resource.parameters.length, 3)
       )


### PR DESCRIPTION
This should fix a bug where the URI templates are missing parameters that were defined on the action-level.

cc @Baggz 
