### PR TITLE
Add support for source maps from Refract

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
     "mocha": "^2.3.0",
-    "protagonist": "1.1.1",
+    "protagonist": "1.2.6",
     "sinon": "^1.17.2"
   }
 }

--- a/src/adapters/refract/helper.coffee
+++ b/src/adapters/refract/helper.coffee
@@ -5,8 +5,37 @@ fixNewLines = (str) ->
   return unless lodash.isString(str)
   str.replace(/\n$/, '')
 
+# Get a source map from an element or its metadata (e.g. title)
+sourceMap = (element) ->
+  sourceMap = lodash.get(element, 'attributes.sourceMap', [])
+
+  if not sourceMap.length
+    # Element itself has no source map, but its `title` may have one
+    sourceMap = lodash.get(element, 'meta.title.attributes.sourceMap', [])
+
+  if not sourceMap.length
+    # Resources must have a URI
+    sourceMap = lodash.get(element, 'attributes.href.attributes.sourceMap', [])
+
+  if not sourceMap.length
+    # Transitions must have a request method, even for API Blueprint shorthand
+    # input using e.g. `### GET`
+    sourceMap = lodash
+      .chain(element)
+      .httpTransactions()
+      .first()
+      .httpRequests()
+      .first()
+      .get('attributes.method.attributes.sourceMap', [])
+      .value() or []
+
+  # This converts a list of `sourceMap` refract elements into a list of source
+  # map location arrays [[pos1, len1], [pos2, len2], ...]
+  lodash.flatten(sourceMap.map((item) -> lodash.contentOrValue(item)))
+
 lodash.mixin({
   fixNewLines
+  sourceMap
 })
 
 module.exports = lodash

--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -72,6 +72,14 @@ module.exports = (resourceElement) ->
       actionRelation: _.chain(transitionElement).get('attributes.relation', '').contentOrValue().value()
     })
 
+    sourceMap = _.sourceMap(resourceElement)
+    if sourceMap.length
+      resource.sourcemap = sourceMap
+
+    actionSourceMap = _.sourceMap(transitionElement)
+    if actionSourceMap.length
+      resource.actionSourcemap = actionSourceMap
+
     requests = []
     responses = []
 

--- a/src/adapters/refract/transformSections.coffee
+++ b/src/adapters/refract/transformSections.coffee
@@ -48,6 +48,10 @@ module.exports = (parentElement) ->
         resources: transformResources(element)
       })
 
+      sourceMap = _.sourceMap(element)
+      if sourceMap.length
+        resourceGroup.sourcemap = sourceMap
+
       resourceGroups.push(resourceGroup)
   )
 


### PR DESCRIPTION
This provides a way to add source map information to the application AST when the input is Refract with source maps. The source maps are exposed using the same format as with #33.

This requires an update to the `protagonist` dev dependency - the older version did not support generating any Refract source maps! Don't forget to `npm install`! Also, tests needed to be updated to better detect the type of parser output since we can't just check for equality with `'refract'` anymore.

cc @Baggz 
