### PR TITLE
Add auth to the Application AST, set it from Refract

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
     "mocha": "^2.3.0",
-    "protagonist": "1.1.1",
+    "protagonist": "1.3.2",
     "sinon": "^1.17.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.7.11",
+  "version": "0.8.0",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/adapters/refract-adapter.coffee
+++ b/src/adapters/refract-adapter.coffee
@@ -2,6 +2,7 @@ _ = require('./refract/helper')
 blueprintApi = require('../blueprint-api')
 
 getDescription = require('./refract/getDescription')
+transformAuth = require('./refract/transformAuth')
 transformSections = require('./refract/transformSections')
 
 transformAst = (element) ->
@@ -33,6 +34,9 @@ transformAst = (element) ->
 
   applicationAst.description = description.raw
   applicationAst.htmlDescription = description.html
+
+  # Authentication definitions
+  applicationAst.authDefinitions = transformAuth(element)
 
   # Sections
   applicationAst.sections = transformSections(element)

--- a/src/adapters/refract/transformAuth.coffee
+++ b/src/adapters/refract/transformAuth.coffee
@@ -1,0 +1,19 @@
+_ = require('./helper')
+
+getDescription = require('./getDescription')
+
+module.exports = (parentElement) ->
+  # Auth information can be present in two places:
+  # 1. An `authSchemes` category that contains definitions
+  # 2. An `authSchems` attribute that defines which definition to use
+  authSchemes = []
+
+  if parentElement.element is 'category'
+    for child in _.get(parentElement, 'content', [])
+      if child and child.element is 'category' and _.get(child, 'meta.classes', []).indexOf('authSchemes') isnt -1
+        authSchemes = authSchemes.concat(child.content)
+
+  if _.get(parentElement, 'attributes.authSchemes')
+    authSchemes = authSchemes.concat(parentElement.attributes.authSchemes)
+
+  authSchemes

--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -3,6 +3,7 @@ blueprintApi = require('../../blueprint-api')
 getDescription = require('./getDescription')
 getHeaders = require('./getHeaders')
 getUriParameters = require('./getUriParameters')
+transformAuth = require('./transformAuth')
 
 module.exports = (resourceElement) ->
   resources = []
@@ -122,6 +123,7 @@ module.exports = (resourceElement) ->
           # exampleId
           attributes: requestAttributes
           resolvedAttributes: requestAttributes
+          authSchemes: transformAuth(httpTransaction)
         })
 
         requests.push(request)

--- a/src/adapters/refract/transformSections.coffee
+++ b/src/adapters/refract/transformSections.coffee
@@ -39,16 +39,18 @@ module.exports = (parentElement) ->
 
       description = getDescription(element)
 
-      # Then create a new section in the Application AST
-      # corresponding to the Category element.
-      resourceGroup = new blueprintApi.Section({
-        name: _.chain(element).get('meta.title', '').contentOrValue().value()
-        description: description.raw
-        htmlDescription: description.html
-        resources: transformResources(element)
-      })
+      classes = _.get(element, 'meta.classes', [])
+      if classes.length is 0 or classes.indexOf('resourceGroup') isnt -1
+        # Then create a new section in the Application AST
+        # corresponding to the Category element.
+        resourceGroup = new blueprintApi.Section({
+          name: _.chain(element).get('meta.title', '').contentOrValue().value()
+          description: description.raw
+          htmlDescription: description.html
+          resources: transformResources(element)
+        })
 
-      resourceGroups.push(resourceGroup)
+        resourceGroups.push(resourceGroup)
   )
 
   # Make sure tu flush the resources into an an artificial

--- a/src/blueprint-api.coffee
+++ b/src/blueprint-api.coffee
@@ -40,6 +40,7 @@ class Blueprint
       version: json.version # Proprietary version of the Application AST (e.g. 17), see http://git.io/bbDJ
       description: json.description # Description of the API (in Markdown)
       htmlDescription: json.htmlDescription # Rendered description of the API
+      authDefinitions: json.authDefinitions
       sections: Section.fromJSON(s) for s in json.sections or [] # Array of resource groups
       validations: JsonSchemaValidation.fromJSON(v) for v in json.validations or [] # Array of JSON Schemas
       dataStructures: json.dataStructures # Array of data struture elements
@@ -53,6 +54,7 @@ class Blueprint
       version: 1.0
       description: null
       htmlDescription: null
+      authDefinitions: []
       sections: []
       validations: []
       dataStructures: []
@@ -85,6 +87,7 @@ class Blueprint
       @version
       @description
       @htmlDescription
+      @authDefinitions
       sections: s.toJSON() for s in @sections
       validations: v.toJSON() for v in @validations
       @dataStructures
@@ -305,6 +308,7 @@ class Request
       exampleId: json.exampleId
       attributes: json.attributes # Request attributes
       resolvedAttributes: json.resolvedAttributes # Expanded request attributes
+      authSchemes: json.authSchemes
     )
 
   constructor: (props = {}) ->
@@ -319,6 +323,7 @@ class Request
       exampleId: 0
       attributes: undefined
       resolvedAttributes: undefined
+      authSchemes: []
     )
 
   toJSON: -> return {
@@ -332,6 +337,7 @@ class Request
     @exampleId
     @attributes
     @resolvedAttributes
+    @authSchemes
   }
 
   # ### `toBlueprint`

--- a/test/fixtures/refract-parse-result-with-auth.json
+++ b/test/fixtures/refract-parse-result-with-auth.json
@@ -1,0 +1,110 @@
+  {
+    "element": "parseResult",
+    "content": [
+      {
+        "element": "category",
+        "meta": {
+          "classes": [
+            "api"
+          ],
+          "title": "Title example"
+        },
+        "attributes": {
+          "meta": [
+            {
+              "element": "member",
+              "meta": {
+                "classes": [
+                  "user"
+                ]
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "content": "FORMAT"
+                },
+                "value": {
+                  "element": "string",
+                  "content": "1A"
+                }
+              }
+            }
+          ]
+        },
+        "content": [
+          {
+            "element": "category",
+            "meta": {
+             "classes": ["authSchemes"]
+            },
+            "content": [
+             {
+               "element": "Basic Authentication Scheme",
+               "meta": {
+                 "id": "Custom Basic Auth"
+               },
+               "content": [
+                 {
+                   "element": "member",
+                   "content": {
+                     "key": {
+                       "element": "string",
+                       "content": "username"
+                     },
+                     "value": {
+                       "element": "string",
+                       "content": "john.doe"
+                     }
+                   }
+                 },
+                 {
+                   "element": "member",
+                   "content": {
+                     "key": {
+                       "element": "string",
+                       "content": "password"
+                     },
+                     "value": {
+                       "element": "string",
+                       "content": "1234password"
+                     }
+                   }
+                 }
+               ]
+             }
+            ]
+          },
+          {
+            "element": "category",
+            "meta": {
+              "classes": ["resourceGroup"]
+            },
+            "content": [
+              {
+                "element": "resource",
+                "content": [
+                  {
+                    "element": "transition",
+                    "content": [
+                      {
+                        "element": "httpTransaction",
+                        "attributes": {
+                          "authSchemes": [
+                            {
+                              "element": "Custom Basic Auth"
+                            }
+                          ]
+                        },
+                        "content": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "error": null
+  }

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -462,5 +462,34 @@ describe('Transformations • Refract', ->
         )
       )
     )
+
+    describe('Authentication', ->
+      applicationAst = null
+
+      before(->
+        applicationAst = convertToApplicationAst(
+          require('./fixtures/refract-parse-result-with-auth.json')
+        )
+      )
+
+      it('Has the correct number of sections', ->
+        assert.strictEqual(applicationAst.sections.length, 1)
+      )
+
+      it('Has the correct number of resources', ->
+        assert.strictEqual(applicationAst.sections[0].resources.length, 1)
+      )
+
+      it('Has authentication definitions', ->
+        assert.strictEqual(applicationAst.authDefinitions[0].element, 'Basic Authentication Scheme')
+        assert.strictEqual(applicationAst.authDefinitions[0].content.length, 2)
+      )
+
+      it('Has authentication information for resource actions', ->
+        request = applicationAst.sections[0].resources[0].requests[0]
+        assert.strictEqual(request.authSchemes.length, 1)
+        assert.strictEqual(request.authSchemes[0].element, 'Custom Basic Auth')
+      )
+    )
   )
 )


### PR DESCRIPTION
This adds API Elements authentication information, as defined in apiaryio/api-elements#14 into the Application AST and makes sure it gets set when given API Elements input like you would get from the Swagger parser.

The output Application AST will be used to display authentication information on the documentation pages in Apiary. I've left the auth info as-is so that we can build components to use the API Elements rather than transforming it further. This should make the future transition to API Elements as the underlying format (rather than Application AST) simpler.

cc @smizell @pksunkara @Baggz 
