### PR TITLE
Support 2 markdown renderers = Robotskirt & markdown-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "precompile": "npm run lint",
     "compile": "coffee -b -c -o lib/ src/",
     "server-test": "mocha --compilers coffee:coffee-script/register -R spec --recursive --timeout 5000",
-    "browser-test": "echo 'Skipping `karma start` because robotskirt does not run in browser - we can turn on browser tests only when we migrate to something else...'",
-    "test": "npm run lint && npm run server-test && npm run browser-test",
+    "test": "npm run lint && npm run server-test",
     "prepublish": "npm run compile"
+  },
+  "engines": {
+    "node": "",
+    "npm": ""
   },
   "repository": {
     "type": "git",
@@ -24,11 +27,10 @@
   },
   "homepage": "https://github.com/apiaryio/metamorphoses",
   "dependencies": {
+    "blueprint-markdown-renderer": "^0.2.3",
     "lodash": "^3.10.1",
     "lodash-api-description": "0.0.2",
-    "media-typer": "^0.3.0",
-    "robotskirt": "^2.7.1",
-    "sanitizer": "^0.1.2"
+    "media-typer": "^0.3.0"
   },
   "devDependencies": {
     "@apiaryio/swagger-zoo": "1.0.0",
@@ -38,12 +40,6 @@
     "coffeeify": "^1.1.0",
     "coffeelint": "^1.11.1",
     "drafter": "^0.2.8",
-    "karma": "^0.13.9",
-    "karma-browserify": "^4.3.0",
-    "karma-chai": "^0.1.0",
-    "karma-firefox-launcher": "^0.1.6",
-    "karma-mocha": "^0.2.0",
-    "karma-mocha-reporter": "^1.1.1",
     "mocha": "^2.3.0",
     "protagonist": "1.3.2",
     "sinon": "^1.17.2"

--- a/src/adapters/apiary-blueprint-adapter.coffee
+++ b/src/adapters/apiary-blueprint-adapter.coffee
@@ -3,8 +3,8 @@ blueprintApi = require('../blueprint-api')
 markdown = require('./markdown')
 
 
-applymarkdownHtml = (obj, targetHtmlProperty) ->
-  obj[targetHtmlProperty] = markdown.toHtmlSync(obj.description or '').trim()
+applymarkdownHtml = (obj, targetHtmlProperty, options) ->
+  obj[targetHtmlProperty] = markdown.toHtmlSync(obj.description or '', options).trim()
   obj
 
 
@@ -14,17 +14,17 @@ applymarkdownHtml = (obj, targetHtmlProperty) ->
 #
 # Go through the AST object and render
 # markdown descriptions.
-apiaryAstToApplicationAst = (ast) ->
+apiaryAstToApplicationAst = (ast, sourcemap, options) ->
   return null unless ast
-  plainJsObject = applymarkdownHtml(ast, 'htmlDescription')
+  plainJsObject = applymarkdownHtml(ast, 'htmlDescription', options)
 
   for section, sectionKey in plainJsObject.sections or [] when section.resources?.length
     for resource, resourceKey in section.resources
       section.resources[resourceKey].uriTemplate = resolveUriTemplate(section.resources[resourceKey], plainJsObject.location)
-      section.resources[resourceKey] = applymarkdownHtml(resource, 'htmlDescription')
+      section.resources[resourceKey] = applymarkdownHtml(resource, 'htmlDescription', options)
       section.resources[resourceKey].requests = [section.resources[resourceKey].request]
 
-    plainJsObject.sections[sectionKey] = applymarkdownHtml(section, 'htmlDescription')
+    plainJsObject.sections[sectionKey] = applymarkdownHtml(section, 'htmlDescription', options)
 
   plainJsObject.version = blueprintApi.Version
   return blueprintApi.Blueprint.fromJSON(plainJsObject)

--- a/src/adapters/markdown.coffee
+++ b/src/adapters/markdown.coffee
@@ -2,7 +2,14 @@
 
 {renderHtml, renderRobotskirtHtml} = require('blueprint-markdown-renderer')
 
-parseMarkdown = (markdown, options = {}, cb) ->
+parseMarkdown = (markdown, params, cb) ->
+  # do not mutate passed-in argument "params", create our own options
+  options = {
+    sanitize: params?.sanitize
+    commonMark: params?.commonMark
+  }
+
+  # sanitize is enabled by default
   options.sanitize ?= true
 
   if options.commonMark
@@ -21,11 +28,17 @@ parseMarkdown = (markdown, options = {}, cb) ->
     return results
 
 
-toHtml = (markdown, options = {}, cb) ->
+toHtml = (markdown, params, cb) ->
+  options = {}
   # Allow for second arg to be the callback
-  if typeof options is 'function'
-    cb = options
-    options = {}
+  if typeof params is 'function'
+    cb = params
+  else
+    # do not mutate passed-in argument "params", create our own options
+    options = {
+      sanitize: params?.sanitize
+      commonMark: params?.commonMark
+    }
 
   unless cb
     return parseMarkdown(markdown, options)
@@ -37,10 +50,10 @@ toHtml = (markdown, options = {}, cb) ->
   return
 
 
-toHtmlSync = (markdown, options = {}) ->
+toHtmlSync = (markdown, params) ->
   if not markdown
     return ''
-  return parseMarkdown(markdown, options)
+  return parseMarkdown(markdown, params)
 
 module.exports = {
   toHtml

--- a/src/adapters/markdown.coffee
+++ b/src/adapters/markdown.coffee
@@ -1,93 +1,31 @@
 # This is our Markdown parser implementation
-# Uses Robotskirt, which is a node binding for a C markdown parser Sundown (also used by Github)
-rs = require('robotskirt')
-sanitizer = require('sanitizer')
 
-renderer = new rs.HtmlRenderer()
+{renderHtml, renderRobotskirtHtml} = require('blueprint-markdown-renderer')
 
-flags = [
-  # ### Autolink
-  #
-  # Parse links even when they are not enclosed in
-  # `<>` characters. Autolinks for the http, https and ftp
-  # protocols will be automatically detected. Email addresses
-  # are also handled, and http links without protocol, but
-  # starting with `www.`
-  rs.EXT_AUTOLINK
-
-  # ### Fenced Code
-  #
-  # Parse fenced code blocks, PHP-Markdown
-  # style. Blocks delimited with 3 or more `~` or backticks
-  # will be considered as code, without the need to be
-  # indented. An optional language name may be added at the
-  # end of the opening fence for the code block.
-  rs.EXT_FENCED_CODE
-
-  # ### Lax Spacing
-  #
-  # HTML blocks do not require to be surrounded
-  # by an empty line as in the Markdown standard.
-  rs.EXT_LAX_HTML_BLOCKS
-
-  # ### Tables
-  #
-  # Parse tables, PHP-Markdown style.
-  rs.EXT_TABLES
-
-  # ### No Intra Emphasis
-  #
-  # Do not parse emphasis inside of words.
-  # Strings such as `foo_bar_baz` will not generate `<em>`
-  # tags.
-  rs.EXT_NO_INTRA_EMPHASIS
-
-  # ### Strikethrough
-  #
-  # Parse strikethrough, PHP-Markdown style
-  # Two `~` characters mark the start of a strikethrough,
-  # e.g. `this is ~~good~~ bad`.
-  rs.EXT_STRIKETHROUGH
-
-  # ### Superscript
-  #
-  # Parse superscripts after the `^` character;
-  # contiguous superscripts are nested together, and complex
-  # values can be enclosed in parenthesis,
-  # e.g. `this is the 2^(nd) time`.
-  rs.EXT_SUPERSCRIPT
-]
-
-parser = new rs.Markdown(renderer, flags)
-parserSync = new rs.Markdown(renderer, flags)
-
-# By default, sanitizer removes src and href attributes
-# if a url policy is not given.
-uriPolicy = (value) -> value
-
-
-parseMarkdown = (markdown, options = {}) ->
-  unless markdown
-    return ''
-
+parseMarkdown = (markdown, options = {}, cb) ->
   options.sanitize ?= true
-  parsed = parserSync.render(markdown)
 
-  if options.sanitize
-    results = sanitizer.sanitize(parsed, uriPolicy)
+  if options.commonMark
+    results = renderHtml(markdown, options)
   else
-    results = parsed
+    results = renderRobotskirtHtml(markdown, options)
 
   # Return <span> if the results are empty. This way other code
   # that renders knows this code has been parsed.
-  return results unless results.trim() is ''
-  return '<span></span>'
+  if results.trim() is ''
+    results = '<span></span>'
+
+  if cb
+    return cb(null, results)
+  else
+    return results
 
 
 toHtml = (markdown, options = {}, cb) ->
   # Allow for second arg to be the callback
   if typeof options is 'function'
-    [cb, options] = [options, {}]
+    cb = options
+    options = {}
 
   unless cb
     return parseMarkdown(markdown, options)
@@ -95,11 +33,14 @@ toHtml = (markdown, options = {}, cb) ->
   unless markdown
     return cb(null, '')
 
-  cb(null, parseMarkdown(markdown, options))
+  parseMarkdown(markdown, options, cb)
+  return
 
 
 toHtmlSync = (markdown, options = {}) ->
-  parseMarkdown(markdown, options)
+  if not markdown
+    return ''
+  return parseMarkdown(markdown, options)
 
 module.exports = {
   toHtml

--- a/src/adapters/refract-adapter.coffee
+++ b/src/adapters/refract-adapter.coffee
@@ -5,7 +5,7 @@ getDescription = require('./refract/getDescription')
 transformAuth = require('./refract/transformAuth')
 transformSections = require('./refract/transformSections')
 
-transformAst = (element) ->
+transformAst = (element, sourcemap, options) ->
 
   applicationAst = new blueprintApi.Blueprint({
     name: _.chain(element).get('meta.title', '').contentOrValue().fixNewLines().value()
@@ -30,16 +30,16 @@ transformAst = (element) ->
     ).value()
 
   # description
-  description = getDescription(element)
+  description = getDescription(element, options)
 
   applicationAst.description = description.raw
   applicationAst.htmlDescription = description.html
 
   # Authentication definitions
-  applicationAst.authDefinitions = transformAuth(element)
+  applicationAst.authDefinitions = transformAuth(element, options)
 
   # Sections
-  applicationAst.sections = transformSections(element)
+  applicationAst.sections = transformSections(element, options)
 
   applicationAst
 

--- a/src/adapters/refract/getDescription.coffee
+++ b/src/adapters/refract/getDescription.coffee
@@ -1,10 +1,10 @@
 _ = require('./helper')
 markdown = require('../markdown')
 
-module.exports = (element) ->
+module.exports = (element, options) ->
   copyElement = _(element).copy().first()
 
   raw = _.fixNewLines(_.content(copyElement) or '')
-  html = _.fixNewLines(if raw then markdown.toHtmlSync(raw) else '')
+  html = _.fixNewLines(if raw then markdown.toHtmlSync(raw, options) else '')
 
   return {raw, html}

--- a/src/adapters/refract/getMetaDescription.coffee
+++ b/src/adapters/refract/getMetaDescription.coffee
@@ -1,7 +1,7 @@
 lodash = require('./helper')
 markdown = require('../markdown')
 
-module.exports = (element) ->
+module.exports = (element, options) ->
   rawDescription = lodash
                     .chain(element)
                     .get('meta.description', '')
@@ -9,4 +9,4 @@ module.exports = (element) ->
                     .fixNewLines()
                     .value()
 
-  markdown.toHtmlSync(rawDescription)
+  markdown.toHtmlSync(rawDescription, options)

--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -1,7 +1,7 @@
 lodash = require('./helper')
 getMetaDescription = require('./getMetaDescription')
 
-getUriParameters = (hrefVariables) ->
+getUriParameters = (hrefVariables, options) ->
   hrefVariablesContent = lodash.content(hrefVariables)
 
   if hrefVariablesContent is undefined
@@ -41,7 +41,7 @@ getUriParameters = (hrefVariables) ->
       default: defaultValue
       required
       type
-      description: getMetaDescription(hrefVariable)
+      description: getMetaDescription(hrefVariable, options)
     }
   )
 

--- a/src/adapters/refract/transformAuth.coffee
+++ b/src/adapters/refract/transformAuth.coffee
@@ -2,7 +2,7 @@ _ = require('./helper')
 
 getDescription = require('./getDescription')
 
-module.exports = (parentElement) ->
+module.exports = (parentElement, options) ->
   # Auth information can be present in two places:
   # 1. An `authSchemes` category that contains definitions
   # 2. An `authSchems` attribute that defines which definition to use

--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -5,10 +5,10 @@ getHeaders = require('./getHeaders')
 getUriParameters = require('./getUriParameters')
 transformAuth = require('./transformAuth')
 
-module.exports = (resourceElement) ->
+module.exports = (resourceElement, options) ->
   resources = []
 
-  resourceDescription = getDescription(resourceElement)
+  resourceDescription = getDescription(resourceElement, options)
 
   transitions = _.transitions(resourceElement)
 
@@ -33,10 +33,10 @@ module.exports = (resourceElement) ->
     ]
 
   transitions.forEach((transitionElement) ->
-    description = getDescription(transitionElement)
+    description = getDescription(transitionElement, options)
 
-    resourceParameters = getUriParameters(_.get(resourceElement, 'attributes.hrefVariables'))
-    actionParameters = getUriParameters(_.get(transitionElement, 'attributes.hrefVariables'))
+    resourceParameters = getUriParameters(_.get(resourceElement, 'attributes.hrefVariables'), options)
+    actionParameters = getUriParameters(_.get(transitionElement, 'attributes.hrefVariables'), options)
 
     attributes = _.dataStructures(transitionElement)
     attributes = if _.isEmpty(attributes) then _.dataStructures(resourceElement) else attributes[0]
@@ -80,7 +80,7 @@ module.exports = (resourceElement) ->
       httpRequest = _(httpTransaction).httpRequests().first()
       httpRequestBody = _(httpRequest).messageBodies().first()
       httpRequestBodySchemas = _(httpRequest).messageBodySchemas().first()
-      httpRequestDescription = getDescription(httpRequest)
+      httpRequestDescription = getDescription(httpRequest, options)
       httpRequestBodyDataStructures = _.dataStructures(httpRequest)
 
       if _.isEmpty(httpRequestBodyDataStructures)
@@ -91,7 +91,7 @@ module.exports = (resourceElement) ->
       httpResponse  = _(httpTransaction).httpResponses().first()
       httpResponseBody = _(httpResponse).messageBodies().first()
       httpResponseBodySchemas = _(httpResponse).messageBodySchemas().first()
-      httpResponseDescription = getDescription(httpResponse)
+      httpResponseDescription = getDescription(httpResponse, options)
       httpResponseBodyDataStructures = _.dataStructures(httpResponse)
 
       if _.isEmpty(httpResponseBodyDataStructures)
@@ -103,7 +103,7 @@ module.exports = (resourceElement) ->
       resource.method = _.chain(httpRequest).get('attributes.method', '').contentOrValue().value()
       resource.actionUriTemplate = _.chain(httpRequest).get('attributes.href', '').contentOrValue().value()
 
-      requestParameters = getUriParameters(_.get(httpRequest, 'attributes.hrefVariables'))
+      requestParameters = getUriParameters(_.get(httpRequest, 'attributes.hrefVariables'), options)
       actionParameters = actionParameters.concat(requestParameters)
 
       httpRequestIsRedundant = _.every(httpTransactions, (httpTransaction) ->
@@ -123,7 +123,7 @@ module.exports = (resourceElement) ->
           # exampleId
           attributes: requestAttributes
           resolvedAttributes: requestAttributes
-          authSchemes: transformAuth(httpTransaction)
+          authSchemes: transformAuth(httpTransaction, options)
         })
 
         requests.push(request)

--- a/src/adapters/refract/transformResources.coffee
+++ b/src/adapters/refract/transformResources.coffee
@@ -2,11 +2,11 @@ _ = require('./helper')
 blueprintApi = require('../../blueprint-api')
 transformResource = require('./transformResource')
 
-module.exports = (element) ->
+module.exports = (element, options) ->
   resources = []
 
   _.resources(element).forEach((resourceElement) ->
-    resources = resources.concat(transformResource(resourceElement))
+    resources = resources.concat(transformResource(resourceElement, options))
   )
 
   resources

--- a/src/adapters/refract/transformSections.coffee
+++ b/src/adapters/refract/transformSections.coffee
@@ -7,7 +7,7 @@ transformResources = require('./transformResources')
 transformResource = require('./transformResource')
 
 
-module.exports = (parentElement) ->
+module.exports = (parentElement, options) ->
   resourceGroups = []
 
   # List of Application AST Resources (= already transformed
@@ -22,7 +22,7 @@ module.exports = (parentElement) ->
     # an artificial section.
     if element.element is 'resource'
       resourcesWithoutGroup = resourcesWithoutGroup.concat(
-        transformResource(element)
+        transformResource(element, options)
       )
 
     if element.element is 'category'
@@ -37,7 +37,7 @@ module.exports = (parentElement) ->
         # Resources have been added to a group, reset.
         resourcesWithoutGroup = []
 
-      description = getDescription(element)
+      description = getDescription(element, options)
 
       classes = _.get(element, 'meta.classes', [])
       if classes.length is 0 or classes.indexOf('resourceGroup') isnt -1
@@ -47,7 +47,7 @@ module.exports = (parentElement) ->
           name: _.chain(element).get('meta.title', '').contentOrValue().value()
           description: description.raw
           htmlDescription: description.html
-          resources: transformResources(element)
+          resources: transformResources(element, options)
         })
 
         resourceGroups.push(resourceGroup)

--- a/test/markdown-commonmark-test.coffee
+++ b/test/markdown-commonmark-test.coffee
@@ -1,13 +1,13 @@
 {assert} = require('chai')
 markdown = require('../src/adapters/markdown')
 
-describe('Markdown rendered with Robotskirt', ->
+describe('Markdown rendered with CommonMark', ->
   describe('#toHtml', ->
     it('Parse a plain paragraph', (done) ->
       markdownString = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
       expectedHtml = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>\n'
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -31,7 +31,7 @@ describe('Markdown rendered with Robotskirt', ->
 
       '''
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -55,7 +55,7 @@ describe('Markdown rendered with Robotskirt', ->
 
       '''
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -79,7 +79,7 @@ describe('Markdown rendered with Robotskirt', ->
 
       '''
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -97,16 +97,16 @@ describe('Markdown rendered with Robotskirt', ->
       <ul>
       <li>Lorem</li>
       <li>Ipsum
-
       <ul>
       <li>Dolor</li>
       <li>Ismaet</li>
-      </ul></li>
+      </ul>
+      </li>
       </ul>
 
       '''
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -124,20 +124,15 @@ describe('Markdown rendered with Robotskirt', ->
 
       expectedHtml = '''
       <h1>Level 1</h1>
-
       <h2>Level 2</h2>
-
       <h3>Level 3</h3>
-
       <h4>Level 4</h4>
-
       <h5>Level 5</h5>
-
       <h6>Level 6</h6>
 
       '''
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -152,13 +147,11 @@ Lorem ipsum dolor isamet.
 
       expectedHtml = '''
       <p>Lorem ipsum dolor isamet.</p>
-
-      <pre><code>alert(&#39;Hello!&#39;);
-      </code></pre>
+      <pre><code>alert('Hello!');</code></pre>
 
       '''
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -172,12 +165,12 @@ Lorem ipsum dolor isamet.
       '''
 
       expectedHtml = '''
-      <pre><code>alert(&#39;Hello!&#39;);
+      <pre><code>alert('Hello!');
       </code></pre>
 
       '''
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -193,13 +186,15 @@ Lorem ipsum dolor isamet.
       '''
 
       expectedHtml = '''
-      <table><thead>
+      <table>
+      <thead>
       <tr>
       <th align="left">First Header</th>
       <th align="center">Second Header</th>
       <th align="right">Third Header</th>
       </tr>
-      </thead><tbody>
+      </thead>
+      <tbody>
       <tr>
       <td align="left">First row</td>
       <td align="center">Data</td>
@@ -215,11 +210,12 @@ Lorem ipsum dolor isamet.
       <td align="center">Cell that spans across two columns</td>
       <td align="right"></td>
       </tr>
-      </tbody></table>
+      </tbody>
+      </table>
 
       '''
 
-      markdown.toHtml(markdownString, (error, html) ->
+      markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
         assert.strictEqual(html, expectedHtml)
         done(error)
       )
@@ -236,7 +232,7 @@ Lorem ipsum dolor isamet.
 
         '''
 
-        markdown.toHtml(markdownString, (error, html) ->
+        markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
           assert.strictEqual(html, expectedHtml)
           done(error)
         )
@@ -252,7 +248,7 @@ Lorem ipsum dolor isamet.
 
         '''
 
-        markdown.toHtml(markdownString, (error, html) ->
+        markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
           assert.strictEqual(html, expectedHtml)
           done(error)
         )
@@ -268,7 +264,7 @@ Lorem ipsum dolor isamet.
 
         '''
 
-        markdown.toHtml(markdownString, (error, html) ->
+        markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
           assert.strictEqual(html, expectedHtml)
           done(error)
         )
@@ -286,7 +282,7 @@ Lorem ipsum dolor isamet.
 
         '''
 
-        markdown.toHtml(markdownString, (error, html) ->
+        markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
           assert.strictEqual(html, expectedHtml)
           done(error)
         )
@@ -298,11 +294,11 @@ Lorem ipsum dolor isamet.
         '''
 
         expectedHtml = '''
-        <p><img src="/image.jpg"></p>
+        <img src="/image.jpg">
 
         '''
 
-        markdown.toHtml(markdownString, (error, html) ->
+        markdown.toHtml(markdownString, {commonMark: true}, (error, html) ->
           assert.strictEqual(html, expectedHtml)
           done(error)
         )
@@ -320,7 +316,7 @@ Lorem ipsum dolor isamet.
 
         '''
 
-        markdown.toHtml(markdownString, {sanitize: false}, (error, html) ->
+        markdown.toHtml(markdownString, {sanitize: false, commonMark: true}, (error, html) ->
           assert.strictEqual(html, expectedHtml)
           done(error)
         )
@@ -336,7 +332,7 @@ Lorem ipsum dolor isamet.
 
         '''
 
-        markdown.toHtml(markdownString, {sanitize: false}, (error, html) ->
+        markdown.toHtml(markdownString, {sanitize: false, commonMark: true}, (error, html) ->
           assert.strictEqual(html, expectedHtml)
           done(error)
         )

--- a/test/options-test.coffee
+++ b/test/options-test.coffee
@@ -63,7 +63,7 @@ describe('Options are passed to markdown renderer functions', ->
         assert.isTrue(markdownSpy.called)
         for callArgs in markdownSpy.args
           assert.equal(callArgs[0], 'I am a description')
-          assert.propertyVal(callArgs[1], 'commonMark', true)
+          assert.deepEqual(callArgs[1], {'commonMark': true})
         assert.isFalse(markdownAsyncSpy.called)
       )
     )
@@ -111,7 +111,7 @@ describe('Options are passed to markdown renderer functions', ->
       it('It does call CommonMark Markdown to HTML renderer', ->
         assert.isTrue(markdownSpy.called)
         for callArgs in markdownSpy.args
-          assert.propertyVal(callArgs[1], 'commonMark', true)
+          assert.deepEqual(callArgs[1], {'commonMark': true})
         assert.isFalse(markdownAsyncSpy.called)
       )
     )

--- a/test/options-test.coffee
+++ b/test/options-test.coffee
@@ -1,0 +1,119 @@
+{assert} = require('chai')
+sinon = require('sinon')
+
+markdown = require('../src/adapters/markdown')
+
+lodash = require('../src/adapters/refract/helper')
+
+refractAdapter = require('../src/adapters/refract-adapter')
+apiaryBlueprintAdapter = require('../src/adapters/apiary-blueprint-adapter')
+apiBlueprintAdapter = require('../src/adapters/api-blueprint-adapter')
+
+describe('Options are passed to markdown renderer functions', ->
+  markdownSpy = null
+  markdownAsyncSpy = null
+  sourcemaps = undefined
+
+  before(->
+    markdownSpy = sinon.spy(markdown, 'toHtmlSync')
+    markdownAsyncSpy = sinon.spy(markdown, 'toHtml')
+  )
+
+  beforeEach(->
+    markdownSpy.reset()
+    markdownAsyncSpy.reset()
+  )
+
+  after(->
+    markdown.toHtmlSync.restore()
+    markdown.toHtml.restore()
+  )
+
+  context('Refract adapter passes options to markdown renderer', ->
+    parseResultElement = JSON.parse(JSON.stringify(require('./fixtures/refract-parse-result-x-summary.json')))
+    apiDescriptionElement = null
+    options = undefined
+
+    beforeEach( ->
+      apiDescriptionElement = lodash.chain(parseResultElement)
+        .content()
+        .find({element: 'category', meta: {classes: ['api']}})
+        .value()
+      refractAdapter.transformAst(apiDescriptionElement, sourcemaps, options)
+    )
+
+    describe('When called without options', ->
+      before(->
+        options = undefined
+      )
+
+      it('It does call Robotskirt Markdown to HTML renderer', ->
+        assert.isTrue(markdownSpy.called)
+        for callArgs in markdownSpy.args
+          assert.isUndefined(callArgs[1])
+        assert.isFalse(markdownAsyncSpy.called)
+      )
+    )
+    describe('When called with options `{commonMark:true}`', ->
+      before(->
+        options = {commonMark: true}
+      )
+
+      it('It does call CommonMark Markdown to HTML renderer', ->
+        assert.isTrue(markdownSpy.called)
+        for callArgs in markdownSpy.args
+          assert.equal(callArgs[0], 'I am a description')
+          assert.propertyVal(callArgs[1], 'commonMark', true)
+        assert.isFalse(markdownAsyncSpy.called)
+      )
+    )
+  )
+
+  context('API Blueprint adapter passes options to markdown renderer', ->
+    parseResultElement = JSON.parse(JSON.stringify(require('./fixtures/refract-parse-result-x-summary.json')))
+    apiDescriptionElement = null
+    options = undefined
+
+    beforeEach((done) ->
+      Drafter = require('drafter')
+      drafter = new Drafter({requireBlueprintName: false})
+      source = """
+        FORMAT: 1A
+        # apiName
+        such _description_.
+        ## GET [/api]
+        Yours lines are good!
+      """
+      drafter.make(source, (err, result = {}) ->
+        return done(err) if err
+        apiBlueprintAdapter.transformAst(result.ast, sourcemaps, options)
+        done(err)
+      )
+    )
+
+    describe('When called without options', ->
+      before(->
+        options = undefined
+      )
+      it('It does call Robotskirt Markdown to HTML renderer', ->
+        assert.isTrue(markdownSpy.called)
+        for callArgs in markdownSpy.args
+          assert.oneOf(callArgs[0], ['Yours lines are good!', 'such _description_.\n'])
+          assert.isUndefined(callArgs[1])
+        assert.isFalse(markdownAsyncSpy.called)
+      )
+    )
+
+    describe('When called with options `{commonMark:true}`', ->
+      before(->
+        options = {commonMark: true}
+      )
+      it('It does call CommonMark Markdown to HTML renderer', ->
+        assert.isTrue(markdownSpy.called)
+        for callArgs in markdownSpy.args
+          assert.propertyVal(callArgs[1], 'commonMark', true)
+        assert.isFalse(markdownAsyncSpy.called)
+      )
+    )
+  )
+)


### PR DESCRIPTION
- `transformAst` now accepts a 3rd argument `options`.
  if `options` contains a `commonMark: true` attribute, the render will use `markdown-it`-based markdown -> HTML rendering.
