### PR TITLE
fix: Provide data structures from Refract into Application AST

### DIFF
--- a/src/adapters/refract-adapter.coffee
+++ b/src/adapters/refract-adapter.coffee
@@ -4,6 +4,7 @@ blueprintApi = require('../blueprint-api')
 getDescription = require('./refract/getDescription')
 transformAuth = require('./refract/transformAuth')
 transformSections = require('./refract/transformSections')
+transformDataStructures = require('./refract/transformDataStructures')
 
 transformAst = (element, sourcemap, options) ->
 
@@ -40,6 +41,7 @@ transformAst = (element, sourcemap, options) ->
 
   # Sections
   applicationAst.sections = transformSections(element, options)
+  applicationAst.dataStructures = transformDataStructures(element, options)
 
   applicationAst
 

--- a/src/adapters/refract/transformDataStructures.coffee
+++ b/src/adapters/refract/transformDataStructures.coffee
@@ -1,0 +1,16 @@
+_ = require('./helper')
+
+module.exports = (parentElement, options) ->
+  dataStructures = []
+
+  _.forEach(_.get(parentElement, 'content'), (element, index) ->
+    if element.element is 'category'
+      classes = _.get(element, 'meta.classes', [])
+
+      if classes.indexOf('dataStructures') isnt -1
+        dataStructures = dataStructures.concat(
+          _.get(element, 'content')
+        )
+  )
+
+  dataStructures

--- a/test/data-structures-test.coffee
+++ b/test/data-structures-test.coffee
@@ -1,6 +1,120 @@
 {assert} = require('chai')
 
+lodash = require('../src/adapters/refract/helper')
 apiBlueprintAdapter = require('../src/adapters/api-blueprint-adapter')
+refractAdapter = require('../src/adapters/refract-adapter')
+
+describe('Transformations • API Elements', ->
+  describe('Multiple Data Structures', ->
+    applicationAst = null
+
+    before(->
+      parseResultElement = require('./fixtures/refract-parse-result-data-structures.json')
+      apiElement = lodash.chain(parseResultElement)
+        .content()
+        .find({element: 'category', meta: {classes: ['api']}})
+        .value()
+
+      applicationAst = refractAdapter.transformAst(apiElement)
+    )
+
+    it('Has correct number of Data Structure elements', ->
+      assert.strictEqual(
+        applicationAst.dataStructures.length,
+        2
+      )
+    )
+
+    it('First element has the correct structure', ->
+      assert.deepEqual(
+        {
+          "element": "dataStructure",
+          "content": [
+            {
+              "element": "object",
+              "meta": {
+                "id": "Message Base"
+              },
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "asdasd-asdasd-asdasd"
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "id"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "asdasd"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        applicationAst.dataStructures[0]
+      )
+    )
+
+    it('Second element has the correct structure', ->
+      assert.deepEqual(
+        {
+          "element": "dataStructure",
+          "content": [
+            {
+              "element": "object",
+              "meta": {
+                "id": "Message"
+              },
+              "content": [
+                {
+                  "element": "member",
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "content": "text"
+                    },
+                    "value": {
+                      "element": "string",
+                      "content": "Hello!"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        applicationAst.dataStructures[1]
+      )
+    )
+  )
+
+  describe('No Data Structures', ->
+    applicationAst = null
+
+    before(->
+      parseResultElement = require('./fixtures/refract-parse-result-no-data-structures.json')
+      apiElement = lodash.chain(parseResultElement)
+        .content()
+        .find({element: 'category', meta: {classes: ['api']}})
+        .value()
+
+      applicationAst = refractAdapter.transformAst(apiElement)
+    )
+
+    it('Has no Data Structure elements', ->
+      assert.strictEqual(
+        applicationAst.dataStructures.length,
+        0
+      )
+    )
+  )
+)
+
 
 describe('Transformations • API Blueprint AST', ->
   describe('Multiple Data Structures', ->

--- a/test/fixtures/refract-parse-result-data-structures.json
+++ b/test/fixtures/refract-parse-result-data-structures.json
@@ -1,0 +1,81 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "dataStructures"
+            ]
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": [
+                {
+                  "element": "object",
+                  "meta": {
+                    "id": "Message Base"
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "description": "asdasd-asdasd-asdasd"
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "id"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "asdasd"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "element": "dataStructure",
+              "content": [
+                {
+                  "element": "object",
+                  "meta": {
+                    "id": "Message"
+                  },
+                  "content": [
+                    {
+                      "element": "member",
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "content": "text"
+                        },
+                        "value": {
+                          "element": "string",
+                          "content": "Hello!"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/refract-parse-result-no-data-structures.json
+++ b/test/fixtures/refract-parse-result-no-data-structures.json
@@ -1,0 +1,15 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "content": []
+    }
+  ]
+}


### PR DESCRIPTION
Data Structures are not copied to the Application AST within the Refract Adapter. They are however copied during the API Blueprint adapter.
