### PR TITLE
Align API Blueprint AST and Refract adapters

### DIFF
--- a/drafter.js
+++ b/drafter.js
@@ -1,0 +1,88 @@
+var fs = require('fs');
+var glob = require('glob');
+
+var _ = require('lodash');
+var protagonist = require('protagonist');
+
+var metamorphoses = require('./lib/metamorphoses.js');
+var blueprintAdapter = metamorphoses.apiBlueprintAdapter;
+var refractAdapter = metamorphoses.refractAdapter;
+var lodash = require('./lib/adapters/refract/helper.js')
+
+var filenames = glob.sync('../drafter/test/fixtures/*/*.apib');
+
+var success = 0;
+var failures = 0;
+var parseError = 0;
+var failureResult = [];
+var totalASTAdapterDuration = 0;
+var totalRefractAdapterDuration = 0;
+
+/*
+ * Convert a duration from `process.hrtime()` into milliseconds.
+ */
+function ms(duration) {
+  return duration[0] * 1000 + duration[1] / 1e6;
+}
+
+_.forEach(filenames, function(filename) {
+  var blueprint = fs.readFileSync(filename, 'utf-8');
+
+  try {
+    var parseResultAST = protagonist.parseSync(blueprint, {type: 'ast'});
+    var parseResultElement = protagonist.parseSync(blueprint);
+  } catch (exception) {
+    parseError += 1;
+    return;
+  }
+
+  // API Blueprint AST
+  var startAST = process.hrtime();
+  var astAST = blueprintAdapter.transformAst(parseResultAST.ast);
+  totalASTAdapterDuration = ms(process.hrtime(startAST));
+
+  // Refract AST
+  var apiElement = lodash.chain(parseResultElement)
+    .content()
+    .find({element: 'category', meta: {classes: ['api']}})
+    .value();
+
+  var startRefract = process.hrtime();
+  var refractAST = refractAdapter.transformAst(apiElement);
+  totalRefractAdapterDuration += ms(process.hrtime(startRefract));
+
+  //if (_.eq(refractAST, astAST)) {
+  if (JSON.stringify(refractAST) === JSON.stringify(astAST)) {
+    process.stdout.write('.');
+    success += 1;
+  } else {
+    process.stdout.write('F');
+    failures += 1;
+
+    failureResult.push({
+      filename: filename,
+      refract: refractAST,
+      ast: astAST,
+    });
+  }
+});
+
+process.stdout.write('\n\n');
+
+_.forEach(failureResult, function(failure) {
+  console.log(failure.filename);
+
+  fs.writeFileSync(failure.filename + '.ast.json', JSON.stringify(failure.ast, null, 2));
+  fs.writeFileSync(failure.filename + '.refract.json', JSON.stringify(failure.refract, null, 2));
+});
+
+process.stdout.write('\n\n');
+
+console.log('Success: ' + success);
+console.log('Failures: ' + failures);
+console.log('Parse Errors: ' + parseError);
+console.log('Average Refract Adapter Speed: ' + (totalRefractAdapterDuration / totalASTAdapterDuration).toFixed(1) + ' times slower than AST Adapter');
+
+if (failures > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
I have build a script to go over all of the test fixtures in Drafter and serialise them as Refract and API Blueprint AST. Using these outputs, I've tested and compared both the API Blueprint and Refract adapters. This pull request attempts resolves these differences so that parsing an API Blueprint via Refract and the Refract adapter should provide identical application AST and behaviour.
#### Current Status

```
$ node drafter.js 
FFF.F.........F....FFF.FF...............F.F...FF.FFFFFFFFFF.FFFFF...F...FFFF.FFF......F....F..................FF.........................................................................

../drafter/test/fixtures/api/action-attributes.apib
../drafter/test/fixtures/api/action-parameters.apib
../drafter/test/fixtures/api/action-request-attributes.apib
../drafter/test/fixtures/api/advanced-action.apib
../drafter/test/fixtures/api/metadata.apib
../drafter/test/fixtures/api/request-only.apib
../drafter/test/fixtures/api/request-parameters.apib
../drafter/test/fixtures/api/resource-attributes.apib
../drafter/test/fixtures/api/resource-parameters.apib
../drafter/test/fixtures/api/resource.apib
../drafter/test/fixtures/mson/array-typed-content.apib
../drafter/test/fixtures/mson/empty-sample.apib
../drafter/test/fixtures/mson/enum.apib
../drafter/test/fixtures/mson/group.apib
../drafter/test/fixtures/mson/inheritance.apib
../drafter/test/fixtures/mson/inner-inheritance.apib
../drafter/test/fixtures/mson/mixin.apib
../drafter/test/fixtures/mson/multiline-description.apib
../drafter/test/fixtures/mson/multiple-default.apib
../drafter/test/fixtures/mson/named-with-types.apib
../drafter/test/fixtures/mson/nontyped-array-sample.apib
../drafter/test/fixtures/mson/nontyped-array.apib
../drafter/test/fixtures/mson/nontyped-object.apib
../drafter/test/fixtures/mson/number-wrong-value.apib
../drafter/test/fixtures/mson/oneof-sample.apib
../drafter/test/fixtures/mson/oneof.apib
../drafter/test/fixtures/mson/primitive-variables.apib
../drafter/test/fixtures/mson/primitive-with-members.apib
../drafter/test/fixtures/mson/primitives.apib
../drafter/test/fixtures/mson/resource-anonymous.apib
../drafter/test/fixtures/mson/resource-primitive-mixin.apib
../drafter/test/fixtures/mson/resource-resolve-basetype.apib
../drafter/test/fixtures/mson/resource-unresolved-reference.apib
../drafter/test/fixtures/mson/string-sample.apib
../drafter/test/fixtures/mson/typed-array-sample.apib
../drafter/test/fixtures/mson/typed-array.apib
../drafter/test/fixtures/mson/typed-object.apib
../drafter/test/fixtures/parse-result/blueprint.apib
../drafter/test/fixtures/render/action-request-attributes.apib
../drafter/test/fixtures/render/issue-328-1.apib
../drafter/test/fixtures/render/issue-328-2.apib


Success: 144
Failures: 41
Parse Errors: 10
```
