### PR TITLE
fix: Ensure refract includes HOST prefix on urls

### DIFF
--- a/src/adapters/refract-adapter.coffee
+++ b/src/adapters/refract-adapter.coffee
@@ -40,7 +40,7 @@ transformAst = (element, sourcemap, options) ->
   applicationAst.authDefinitions = transformAuth(element, options)
 
   # Sections
-  applicationAst.sections = transformSections(element, options)
+  applicationAst.sections = transformSections(element, applicationAst.location, options)
   applicationAst.dataStructures = transformDataStructures(element, options)
 
   applicationAst

--- a/src/adapters/refract/transformResources.coffee
+++ b/src/adapters/refract/transformResources.coffee
@@ -2,11 +2,11 @@ _ = require('./helper')
 blueprintApi = require('../../blueprint-api')
 transformResource = require('./transformResource')
 
-module.exports = (element, options) ->
+module.exports = (element, location, options) ->
   resources = []
 
   _.resources(element).forEach((resourceElement) ->
-    resources = resources.concat(transformResource(resourceElement, options))
+    resources = resources.concat(transformResource(resourceElement, location, options))
   )
 
   resources

--- a/src/adapters/refract/transformSections.coffee
+++ b/src/adapters/refract/transformSections.coffee
@@ -7,7 +7,7 @@ transformResources = require('./transformResources')
 transformResource = require('./transformResource')
 
 
-module.exports = (parentElement, options) ->
+module.exports = (parentElement, location, options) ->
   resourceGroups = []
 
   # List of Application AST Resources (= already transformed
@@ -22,7 +22,7 @@ module.exports = (parentElement, options) ->
     # an artificial section.
     if element.element is 'resource'
       resourcesWithoutGroup = resourcesWithoutGroup.concat(
-        transformResource(element, options)
+        transformResource(element, location, options)
       )
 
     if element.element is 'category'
@@ -47,7 +47,7 @@ module.exports = (parentElement, options) ->
           name: _.chain(element).get('meta.title', '').contentOrValue().value()
           description: description.raw
           htmlDescription: description.html
-          resources: transformResources(element, options)
+          resources: transformResources(element, location, options)
         })
 
         resourceGroups.push(resourceGroup)

--- a/test/fixtures/refract-parse-result-host-trailing.json
+++ b/test/fixtures/refract-parse-result-host-trailing.json
@@ -1,0 +1,88 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "attributes": {
+        "meta": [
+          {
+            "element": "member",
+            "meta": {
+              "classes": [
+                "user"
+              ]
+            },
+            "content": {
+              "key": {
+                "element": "string",
+                "content": "HOST"
+              },
+              "value": {
+                "element": "string",
+                "content": "https://example.com/prefix/"
+              }
+            }
+          }
+        ]
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": ""
+              },
+              "attributes": {
+                "href": "/example"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": ""
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "204"
+                          },
+                          "content": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+

--- a/test/fixtures/refract-parse-result-host.json
+++ b/test/fixtures/refract-parse-result-host.json
@@ -1,0 +1,88 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": ""
+      },
+      "attributes": {
+        "meta": [
+          {
+            "element": "member",
+            "meta": {
+              "classes": [
+                "user"
+              ]
+            },
+            "content": {
+              "key": {
+                "element": "string",
+                "content": "HOST"
+              },
+              "value": {
+                "element": "string",
+                "content": "https://example.com/prefix"
+              }
+            }
+          }
+        ]
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": ""
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": ""
+              },
+              "attributes": {
+                "href": "/example"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": ""
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "204"
+                          },
+                          "content": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -502,4 +502,32 @@ describe('Transformations • Refract', ->
       )
     )
   )
+
+  describe('Host metadata', ->
+    describe('without a trailing slash', ->
+      ast = null
+      resource = null
+      before( ->
+        ast = convertToApplicationAst(require('./fixtures/refract-parse-result-host.json'))
+        resource = ast.sections[0].resources[0]
+      )
+
+      it('has a url including the host prefix', ->
+        assert.equal(resource.url, '/prefix/example')
+      )
+    )
+
+    describe('with a trailing slash', ->
+      ast = null
+      resource = null
+      before( ->
+        ast = convertToApplicationAst(require('./fixtures/refract-parse-result-host-trailing.json'))
+        resource = ast.sections[0].resources[0]
+      )
+
+      it('has a url including the host prefix', ->
+        assert.equal(resource.url, '/prefix/example')
+      )
+    )
+  )
 )


### PR DESCRIPTION
In order to align the behaviour of Apiary Blueprint and API Blueprint adapters with the Refract adapter. This pull request fixes a TODO from the source code:

> TODO: `url` should contain a possible HOST suffix

In the API Blueprint and Apiary Blueprint adapters, the HOST path is prefixed onto the URL. This brings the same behaviour for the Refract adapter.
- [API Blueprint Adapter behaviour](https://github.com/apiaryio/metamorphoses/blob/master/src/adapters/api-blueprint-adapter.coffee#L371)

---

This behaviour is actually really weird to me, but that's how it is in the legacy side of the Application AST. Apiary relies on the behaviour to ensure the mock server and proxy server use the path including the HOST metadata path as a prefix.
