### PR TITLE
fix: Correct the trimming of descriptions and names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Metamorphoses Changelog
 
+# Master
+
+### Enhancements
+
+- Streamlined the trimming of newlines in all descriptions just to trim one newline character
+
+### Bug Fixes
+
+- Action name and Resource name are now completely trimmed in Refract adapter to be consistent with APIB AST adapter.
+
 ## 0.9.1
 
 ### Bug Fixes

--- a/src/adapters/api-blueprint-adapter.coffee
+++ b/src/adapters/api-blueprint-adapter.coffee
@@ -152,12 +152,8 @@ legacyRequestFrom1ARequest = (request, action, resource, exampleId = undefined, 
     exampleId: exampleId
   )
 
-  if request.description
-    legacyRequest.description     = trimLastNewline(request.description)
-    legacyRequest.htmlDescription = trimLastNewline(markdown.toHtmlSync(request.description, options))
-  else
-    legacyRequest.description     = ''
-    legacyRequest.htmlDescription = ''
+  legacyRequest.description     = trimLastNewline(request.description) or ''
+  legacyRequest.htmlDescription = trimLastNewline(markdown.toHtmlSync(request.description, options)) or ''
 
   legacyRequest.reference = request.reference
 
@@ -191,12 +187,8 @@ legacyResponseFrom1AResponse = (response, action, resource, exampleId = undefine
     exampleId: exampleId
   )
 
-  if response.description
-    legacyResponse.description     = trimLastNewline(response.description)
-    legacyResponse.htmlDescription = trimLastNewline(markdown.toHtmlSync(response.description, options))
-  else
-    legacyResponse.description     = ''
-    legacyResponse.htmlDescription = ''
+  legacyResponse.description     = trimLastNewline(response.description) or ''
+  legacyResponse.htmlDescription = trimLastNewline(markdown.toHtmlSync(response.description, options)) or ''
 
   legacyResponse.reference = response.reference
 
@@ -270,20 +262,10 @@ legacyResourcesFrom1AResource = (legacyUrlConverterFn, resource, sourcemap, opti
     legacyResource.headers       = legacyHeadersFrom1AHeaders(resource.headers)
     legacyResource.actionHeaders = legacyHeadersFrom1AHeaders(action.headers)
 
-
     legacyResource.description = trimLastNewline(resource.description) or ''
+    legacyResource.htmlDescription = trimLastNewline(markdown.toHtmlSync(resource.description, options)) or ''
 
-    if resource.description?.length
-      legacyResource.htmlDescription = trimLastNewline(markdown.toHtmlSync(resource.description.trim(), options))
-    else
-      legacyResource.htmlDescription = ''
-
-
-    if action.name?.length
-      legacyResource.actionName = action.name.trim()
-    else
-      legacyResource.actionName = ''
-
+    legacyResource.actionName = action.name?.trim() or ''
 
     unless not resource.model
       legacyResource.model = resource.model
@@ -302,12 +284,8 @@ legacyResourcesFrom1AResource = (legacyUrlConverterFn, resource, sourcemap, opti
 
     legacyResource.parameters = actionParameters or resourceParameters or []
 
-    if action.description
-      legacyResource.actionDescription     = trimLastNewline(action.description)
-      legacyResource.actionHtmlDescription = trimLastNewline(markdown.toHtmlSync(action.description, options))
-    else
-      legacyResource.actionDescription     = ''
-      legacyResource.actionHtmlDescription = ''
+    legacyResource.actionDescription     = trimLastNewline(action.description) or ''
+    legacyResource.actionHtmlDescription = trimLastNewline(markdown.toHtmlSync(action.description, options)) or ''
 
     # Requests - for legacy usage, please, save '.request' too
     requests = legacyRequestsFrom1AExamples(action, resource)
@@ -352,7 +330,7 @@ legacyASTfrom1AAST = (ast, sourcemap, options) ->
     metadata: []
   })
 
-  legacyAST.description = "#{ast.description}".trim() or ''
+  legacyAST.description = trimLastNewline(ast.description) or ''
   legacyAST.htmlDescription = trimLastNewline(markdown.toHtmlSync(ast.description, options)) or ''
 
   # Metadata
@@ -393,14 +371,8 @@ legacyASTfrom1AAST = (ast, sourcemap, options) ->
     if sourcemap?.resourceGroups?[i]?
       setSourcemap(legacySection, sourcemap.resourceGroups[i])
 
-    resourceGroupDescription = resourceGroup.description?.trim()
-
-    if resourceGroupDescription
-      legacySection.description =     trimLastNewline(resourceGroupDescription)
-      legacySection.htmlDescription = trimLastNewline(markdown.toHtmlSync(resourceGroupDescription, options))
-    else
-      legacySection.description     = ''
-      legacySection.htmlDescription = ''
+    legacySection.description     = trimLastNewline(resourceGroup.description) or ''
+    legacySection.htmlDescription = trimLastNewline(markdown.toHtmlSync(resourceGroup.description, options)) or ''
 
     # Resources
     for resource, j in resourceGroup.resources

--- a/src/adapters/refract-adapter.coffee
+++ b/src/adapters/refract-adapter.coffee
@@ -9,7 +9,7 @@ transformDataStructures = require('./refract/transformDataStructures')
 transformAst = (element, sourcemap, options) ->
 
   applicationAst = new blueprintApi.Blueprint({
-    name: _.chain(element).get('meta.title', '').contentOrValue().fixNewLines().value()
+    name: _.chain(element).get('meta.title', '').contentOrValue().trimLastNewline().value()
     version: blueprintApi.Version
     metadata: []
   })

--- a/src/adapters/refract/getDescription.coffee
+++ b/src/adapters/refract/getDescription.coffee
@@ -4,7 +4,7 @@ markdown = require('../markdown')
 module.exports = (element, options) ->
   copyElement = _(element).copy().first()
 
-  raw = _.fixNewLines(_.content(copyElement) or '')
-  html = _.fixNewLines(if raw then markdown.toHtmlSync(raw, options) else '')
+  raw = _.trimLastNewline(_.content(copyElement) or '')
+  html = _.trimLastNewline(if raw then markdown.toHtmlSync(raw, options) else '')
 
   return {raw, html}

--- a/src/adapters/refract/getMetaDescription.coffee
+++ b/src/adapters/refract/getMetaDescription.coffee
@@ -6,7 +6,7 @@ module.exports = (element, options) ->
                     .chain(element)
                     .get('meta.description', '')
                     .contentOrValue()
-                    .fixNewLines()
+                    .trimLastNewline()
                     .value()
 
   markdown.toHtmlSync(rawDescription, options)

--- a/src/adapters/refract/helper.coffee
+++ b/src/adapters/refract/helper.coffee
@@ -1,12 +1,12 @@
 lodash = require('lodash')
 require('lodash-api-description')(lodash)
 
-fixNewLines = (str) ->
+trimLastNewline = (str) ->
   return unless lodash.isString(str)
   str.replace(/\n$/, '')
 
 lodash.mixin({
-  fixNewLines
+  trimLastNewline
 })
 
 module.exports = lodash

--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -72,7 +72,7 @@ module.exports = (resourceElement, location, options) ->
       url: transitionUrl
       uriTemplate: transitionUriTemplate
 
-      name: _.chain(resourceElement).get('meta.title', '').contentOrValue().value()
+      name: _.chain(resourceElement).get('meta.title', '').contentOrValue().value().trim()
 
       # We can safely leave these empty for now.
       headers: {}
@@ -80,7 +80,7 @@ module.exports = (resourceElement, location, options) ->
 
       description: resourceDescription.raw
       htmlDescription: resourceDescription.html
-      actionName: _.chain(transitionElement).get('meta.title', '').contentOrValue().value()
+      actionName: _.chain(transitionElement).get('meta.title', '').contentOrValue().value().trim()
 
       # Model has been deprecated in the API Blueprint format,
       # therfore we can safely skip it.

--- a/test/options-test.coffee
+++ b/test/options-test.coffee
@@ -96,7 +96,8 @@ describe('Options are passed to markdown renderer functions', ->
       it('It does call Robotskirt Markdown to HTML renderer', ->
         assert.isTrue(markdownSpy.called)
         for callArgs in markdownSpy.args
-          assert.oneOf(callArgs[0], ['Yours lines are good!', 'such _description_.\n'])
+          # Allow empty string because resource group description
+          assert.oneOf(callArgs[0], ['Yours lines are good!', 'such _description_.\n', ''])
           assert.isUndefined(callArgs[1])
         assert.isFalse(markdownAsyncSpy.called)
       )

--- a/test/transformation-test.coffee
+++ b/test/transformation-test.coffee
@@ -117,8 +117,7 @@ describe('Transformations', ->
             assert.equal(ast.name, 'API name')
           )
           it('I got API description', ->
-            expected = if type is 'refract' then 'Lorem ipsum 1\n' else 'Lorem ipsum 1'
-            assert.equal(ast.description, expected)
+            assert.equal(ast.description, 'Lorem ipsum 1\n')
           )
           it('I got API HTML description', ->
             assert.equal(ast.htmlDescription, '<p>Lorem ipsum 1</p>')
@@ -130,8 +129,7 @@ describe('Transformations', ->
             assert.equal(ast.sections[0].name, 'Name')
           )
           it('group has correct description', ->
-            expected = if type is 'refract' then 'Lorem ipsum 2\n' else 'Lorem ipsum 2'
-            assert.equal(ast.sections[0].description, expected)
+            assert.equal(ast.sections[0].description, 'Lorem ipsum 2\n')
           )
           it('group has HTML description', ->
             assert.equal(ast.sections[0].htmlDescription, '<p>Lorem ipsum 2</p>')


### PR DESCRIPTION
This pull request aligns the behaviour of trimming names and descriptions across API Blueprint and Refract adapters. The different adapters trimmed components differently and result in different Application ASTs based on the given content.

This is very clear in how the tests are previously written where there are conditionals to change the expected values of tests based not he adapter.

``` coffeescript
expected = if type is 'refract' then 'Lorem ipsum 1\n' else 'Lorem ipsum 1'
```
