### PR TITLE
Remove .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,0 @@
-@apiaryio:registry=https://registry.apiary-internal.com/
-//registry.apiary-internal.com/:_authToken=${NPM_TOKEN}
-@apiaryio:always-auth=true
-@apiaryio:email=sre@apiary.io
-registry=https://registry.npmjs.org/


### PR DESCRIPTION
This project is public and has no private NPM dependencies. Having this file requires you to have an `NPM_TOKEN` set in your environment to be able to run `npm install` inside this repository which is unnecessary since it doesn't have any private dependencies.
