### PR TITLE
fix(API Elements): Provide actionAttributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Action name and Resource name are now completely trimmed in Refract adapter to be consistent with APIB AST adapter.
 - Do not add resource to Apiary AST if no transition exists for that resource in Refract adapter.
+- Provide actionAttributes in Refract adapter just like the API Blueprint AST
+  adapter.
 
 ## 0.9.1
 

--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -40,9 +40,9 @@ module.exports = (resourceElement, location, options) ->
     resourceParameters = getUriParameters(_.get(resourceElement, 'attributes.hrefVariables'), options)
     actionParameters = getUriParameters(_.get(transitionElement, 'attributes.hrefVariables'), options)
 
-    attributes = _.dataStructures(transitionElement)
-    attributes = if _.isEmpty(attributes) then _.dataStructures(resourceElement) else attributes[0]
+    attributes = _.dataStructures(resourceElement)
     attributes = if _.isEmpty(attributes) then undefined else attributes[0]
+    actionAttributes = _.get(transitionElement, 'attributes.data')
 
     # Resource
     #
@@ -73,6 +73,7 @@ module.exports = (resourceElement, location, options) ->
       actionDescription: description.raw
       actionHtmlDescription: description.html
       attributes
+      actionAttributes: actionAttributes
 
       actionRelation: _.chain(transitionElement).get('attributes.relation', '').contentOrValue().value()
     })


### PR DESCRIPTION
This PR adds support for actionAttributes in the Refract adapter in the same way they are in the API Blueprint AST adapter.

Implementation in API Blueprint AST Adapter: https://github.com/apiaryio/metamorphoses/blob/e28822d61f1acbd9c8b8c455fc2f36a1d1382803/src/blueprint-api.coffee#L190
