### PR TITLE
Align parameter handling for API Blueprint AST and Refract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Prevent wrapping parameter values in dictionaries inside the values list in
   the Refract Adapter. This aligns the behaviour with the API Blueprint
   adapter.
+- A parameter is optional by default when there are no type attributes and
+  required attribute in the Refract Adapter.
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Action name and Resource name are now completely trimmed in Refract adapter to be consistent with APIB AST adapter.
 - Do not add resource to Apiary AST if no transition exists for that resource in Refract adapter.
 - Provide actionAttributes in Refract adapter just like the API Blueprint AST
+- Prevent wrapping parameter values in dictionaries inside the values list in
+  the Refract Adapter. This aligns the behaviour with the API Blueprint
   adapter.
 
 ## 0.9.1

--- a/src/adapters/api-blueprint-adapter.coffee
+++ b/src/adapters/api-blueprint-adapter.coffee
@@ -223,6 +223,7 @@ getParametersOf = (obj, options) ->
     if param.description
       param.description = markdown.toHtmlSync(param.description, options)
     param.values = ((if typeof item is 'string' then item else item.value) for item in param.values)
+    param.type = 'string' if not param.type
     params.push(param)
 
   if not params.length

--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -46,6 +46,9 @@ getUriParameters = (hrefVariables, options) ->
     if not lodash.isArray(memberContentValueContent.value())
       exampleValue = memberContentValueContent.value()?.toString() or ''
     else
+      if type is 'enum'
+        type = memberContentValueContent.first().get('element', 'enum').value()
+
       values = memberContentValueContent.map((element) ->
         lodash(element).content().value()?.toString()
       ).value()

--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -13,8 +13,10 @@ getUriParameters = (hrefVariables, options) ->
                         .get('attributes.typeAttributes')
                         .value()
 
-    required = typeAttributes?.indexOf('required') isnt -1
-    required = typeAttributes?.indexOf('optional') is -1
+    if typeAttributes
+      required = typeAttributes.indexOf('optional') is -1
+    else
+      required = true
 
     memberContent = lodashedHrefVariable.content()
     key = memberContent.get('key').contentOrValue().value()

--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -24,12 +24,22 @@ getUriParameters = (hrefVariables, options) ->
     type = memberContentValue.get('element').value()
 
     sampleValues = memberContentValue.get('attributes.samples', '').contentOrValue()
-    defaultValue = memberContentValue.get('attributes.default', '').contentOrValue().value().toString()
+    defaultValue = memberContentValue.get('attributes.default', '').contentOrValue()
     exampleValue = ''
     values = []
 
-    if lodash.isArray(sampleValues.value())
-      exampleValue = sampleValues.first().contentOrValue().value().toString()
+    if lodash.isArray(defaultValue.value())
+      defaultValue = defaultValue.first().contentOrValue().value().toString()
+    else
+      defaultValue = defaultValue.value().toString()
+
+    if sampleValues.value()
+      example = sampleValues.first().contentOrValue()
+
+      if lodash.isArray(example.value())
+        exampleValue = example.first().contentOrValue().value().toString()
+      else
+        exampleValue = example.value().toString()
 
     memberContentValueContent = memberContentValue.content()
 

--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -21,14 +21,18 @@ getUriParameters = (hrefVariables, options) ->
     memberContentValue = memberContent.get('value')
     type = memberContentValue.get('element').value()
 
+    sampleValues = memberContentValue.get('attributes.samples', '').contentOrValue()
     defaultValue = memberContentValue.get('attributes.default', '').contentOrValue().value().toString()
     exampleValue = ''
     values = []
 
+    if lodash.isArray(sampleValues.value())
+      exampleValue = sampleValues.first().contentOrValue().value().toString()
+
     memberContentValueContent = memberContentValue.content()
 
     if not lodash.isArray(memberContentValueContent.value())
-      exampleValue = memberContentValueContent.value()?.toString()
+      exampleValue = memberContentValueContent.value()?.toString() or ''
     else
       values = memberContentValueContent.map((element) ->
         lodash(element).content().value()?.toString()

--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -31,7 +31,7 @@ getUriParameters = (hrefVariables, options) ->
       exampleValue = memberContentValueContent.value()?.toString()
     else
       values = memberContentValueContent.map((element) ->
-        {value: lodash(element).content().value()?.toString()}
+        lodash(element).content().value()?.toString()
       ).value()
 
     return {

--- a/test/getUriParameters-test.coffee
+++ b/test/getUriParameters-test.coffee
@@ -67,12 +67,19 @@ describe('Transformation • Refract • getUriParameters' , ->
                   'element': 'enum',
                   'attributes': {
                     'samples': [
+                      [
+                        {
+                          'element': 'number',
+                          'content': 2
+                        }
+                      ]
+                    ],
+                    'default': [
                       {
                         'element': 'number',
-                        'content': 2
+                        'content': 1
                       }
-                    ],
-                    'default': 1
+                    ]
                   },
                   'content': [
                     {

--- a/test/getUriParameters-test.coffee
+++ b/test/getUriParameters-test.coffee
@@ -66,6 +66,12 @@ describe('Transformation • Refract • getUriParameters' , ->
                 'value': {
                   'element': 'enum',
                   'attributes': {
+                    'samples': [
+                      {
+                        'element': 'number',
+                        'content': 2
+                      }
+                    ],
                     'default': 1
                   },
                   'content': [
@@ -94,7 +100,7 @@ describe('Transformation • Refract • getUriParameters' , ->
             'type': 'enum',
             'required': false,
             'default': '1',
-            'example': '',
+            'example': '2',
             'values': [
                 '1',
                 '2',

--- a/test/getUriParameters-test.coffee
+++ b/test/getUriParameters-test.coffee
@@ -96,15 +96,9 @@ describe('Transformation • Refract • getUriParameters' , ->
             'default': '1',
             'example': '',
             'values': [
-                {
-                    'value': '1'
-                },
-                {
-                    'value': '2'
-                },
-                {
-                    'value': '3'
-                }
+                '1',
+                '2',
+                '3'
             ]
           }
         ]

--- a/test/getUriParameters-test.coffee
+++ b/test/getUriParameters-test.coffee
@@ -109,6 +109,39 @@ describe('Transformation • Refract • getUriParameters' , ->
           }
         ]
       },
+      # Parameter is required by default with no type attributes
+      {
+        hrefVariables: {
+          'element': 'hrefVariables',
+          'content': [
+            {
+              'element': 'member',
+              'content': {
+                'key': {
+                  'element': 'string',
+                  'content': 'question_id'
+                },
+                'value': {
+                  'element': 'number',
+                  'content': 1
+                }
+              }
+            }
+          ]
+        },
+        parameters: [
+          {
+            'key': 'question_id',
+            'description': '',
+            'type': 'number',
+            'required': true,
+            'default': '',
+            'example': '1',
+            'values': [
+            ]
+          }
+        ]
+      },
     ]
 
     it('should be transformed into a `parameter` object', ->

--- a/test/getUriParameters-test.coffee
+++ b/test/getUriParameters-test.coffee
@@ -104,7 +104,7 @@ describe('Transformation • Refract • getUriParameters' , ->
           {
             'key': 'page',
             'description': '',
-            'type': 'enum',
+            'type': 'number',
             'required': false,
             'default': '1',
             'example': '2',


### PR DESCRIPTION
This pull request aligns the behaviour for parameters in API Blueprint and Refract.

The following problems have been addressed:
- The first sample value is used as the example value if there is no content. The behaviour from API Elements specification (http://api-elements.readthedocs.io/en/latest/element-definitions/#properties_13) is now used.
  > Note, if the content is a Variable Value the sample type attribute should be used instead (see typeAttributes)
- Removes wrapping parameter values in an object in the Application AST. The API Blueprint Adapter converts parameter values to a flat array of values instead of wrapping them in a dictionary. This change makes them consistent.
