### PR TITLE
Align actionUriTemplate behaviour in the adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   required attribute in the Refract Adapter.
 - Set the action uri template to the actual uri template for an action instead
   of the resource in the API Blueprint Adapter.
+- Expose the transition's href as the action uri template in the
+  Refract Adapter.
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   adapter.
 - A parameter is optional by default when there are no type attributes and
   required attribute in the Refract Adapter.
+- Set the action uri template to the actual uri template for an action instead
+  of the resource in the API Blueprint Adapter.
 
 ## 0.9.1
 

--- a/src/adapters/api-blueprint-adapter.coffee
+++ b/src/adapters/api-blueprint-adapter.coffee
@@ -255,7 +255,7 @@ legacyResourcesFrom1AResource = (legacyUrlConverterFn, resource, sourcemap, opti
       setSourcemap(legacyResource, actionSourcemap, 'actionSourcemap')
 
     legacyResource.url         = legacyUrlConverterFn(action.attributes?.uriTemplate or resource.uriTemplate)
-    legacyResource.uriTemplate = resource.uriTemplate
+    legacyResource.uriTemplate = action.attributes?.uriTemplate or resource.uriTemplate
 
     legacyResource.method = action.method
     legacyResource.name   = resource.name?.trim() or ''

--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -49,12 +49,12 @@ module.exports = (resourceElement, location, options) ->
     # * `method` is set when iterating `httpTransaction`
     # * Dtto, `actionUriTemplate`
     #
-    transitionUriTemplate = _.chain(transitionElement).get('attributes.href', resourceUriTemplate).contentOrValue().value()
-    transitionUrl = urlPrefix + transitionUriTemplate
+    transitionUriTemplate = _.chain(transitionElement).get('attributes.href', '').contentOrValue().value()
 
     resource = new blueprintApi.Resource({
-      url: transitionUrl
-      uriTemplate: transitionUriTemplate
+      url: urlPrefix + (transitionUriTemplate or resourceUriTemplate)
+      uriTemplate: transitionUriTemplate or resourceUriTemplate
+      actionUriTemplate: transitionUriTemplate
 
       name: _.chain(resourceElement).get('meta.title', '').contentOrValue().value().trim()
 
@@ -104,9 +104,8 @@ module.exports = (resourceElement, location, options) ->
       else
         responseAttributes = httpResponseBodyDataStructures[0]
 
-      # In refract just here we have method and href
+      # In refract just here we have method
       resource.method = _.chain(httpRequest).get('attributes.method', '').contentOrValue().value()
-      resource.actionUriTemplate = _.chain(httpRequest).get('attributes.href', '').contentOrValue().value()
 
       requestParameters = getUriParameters(_.get(httpRequest, 'attributes.hrefVariables'), options)
       actionParameters = actionParameters.concat(requestParameters)

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -267,6 +267,10 @@ describe('Transformations • Refract', ->
           assert.equal(resource.uriTemplate, '/test/{id}{?arg}')
         )
 
+        it('actionUriTemplate equals to `/test/{id}{?arg}`', ->
+          assert.equal(resource.actionUriTemplate, '/test/{id}{?arg}')
+        )
+
         it('has two parameters', ->
           assert.equal(resource.parameters.length, 2)
         )
@@ -312,6 +316,10 @@ describe('Transformations • Refract', ->
 
         it('uriTemplate equals to `/test`', ->
           assert.equal(resource.uriTemplate, '/test')
+        )
+
+        it('actionUriTemplate is empty', ->
+          assert.equal(resource.actionUriTemplate, '')
         )
 
         it('has schema', ->


### PR DESCRIPTION
Changes:
-  Expose the transition's href as the action uri template in the Refract Adapter, just like the API Blueprint adapter.
- Set the action uri template to the actual uri template for an action instead of the resource in the API Blueprint Adapter.
