### PR TITLE
fix(refract): Prevent empty requests and include exampleId

### DIFF
--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -115,18 +115,32 @@ module.exports = (resourceElement, location, options) ->
         _.isEqual(httpRequestToCompareWith, httpRequest)
       )
 
-      if (httpTransactionIndex is 0) or (not httpRequestIsRedundant)
+      requestName = _.chain(httpRequest).get('meta.title', '').contentOrValue().value()
+      requestHeaders = getHeaders(httpRequest)
+      requestBody = trimLastNewline(if _.content(httpRequestBody) then _.content(httpRequestBody) else '')
+      requestSchema = trimLastNewline(if _.content(httpRequestBodySchemas) then _.content(httpRequestBodySchemas) else '')
+      requestAuthSchemes = transformAuth(httpTransaction, options)
+
+      httpRequestIsEmpty = _.isEmpty(requestName) \
+        and _.isEmpty(httpRequestDescription.raw) \
+        and _.isEmpty(requestHeaders) \
+        and _.isEmpty(requestBody) \
+        and _.isEmpty(requestSchema) \
+        and _.isEmpty(requestAttributes) \
+        and _.isEmpty(requestAuthSchemes)
+
+      if (not httpRequestIsEmpty) and (httpTransactionIndex is 0 or not httpRequestIsRedundant)
         request = new blueprintApi.Request({
-          name: _.chain(httpRequest).get('meta.title', '').contentOrValue().value()
+          name: requestName
           description: httpRequestDescription.raw
           htmlDescription: httpRequestDescription.html
-          headers: getHeaders(httpRequest)
+          headers: requestHeaders
           # reference
-          body: trimLastNewline(if _.content(httpRequestBody) then _.content(httpRequestBody) else '')
-          schema: trimLastNewline(if _.content(httpRequestBodySchemas) then _.content(httpRequestBodySchemas) else '')
+          body: requestBody
+          schema: requestSchema
           # exampleId
           attributes: requestAttributes
-          authSchemes: transformAuth(httpTransaction, options)
+          authSchemes: requestAuthSchemes
         })
 
         requests.push(request)
@@ -150,6 +164,15 @@ module.exports = (resourceElement, location, options) ->
     resource.requests = requests
     resource.request = requests[0]
     resource.responses = responses
+
+    if not resource.request
+      resource.request = new blueprintApi.Request({
+        name: ''
+        description: ''
+        htmlDescription: ''
+      })
+
+      resource.requests.push(resource.request)
 
     resource.resourceParameters = resourceParameters
     resource.actionParameters = actionParameters

--- a/src/adapters/refract/transformResource.coffee
+++ b/src/adapters/refract/transformResource.coffee
@@ -138,7 +138,7 @@ module.exports = (resourceElement, location, options) ->
           # reference
           body: requestBody
           schema: requestSchema
-          # exampleId
+          exampleId: httpTransactionIndex
           attributes: requestAttributes
           authSchemes: requestAuthSchemes
         })
@@ -154,7 +154,7 @@ module.exports = (resourceElement, location, options) ->
           # reference
           body: trimLastNewline(if _.content(httpResponseBody) then _.content(httpResponseBody) else '')
           schema: trimLastNewline(if _.content(httpResponseBodySchemas) then _.content(httpResponseBodySchemas) else '')
-          # exampleId
+          exampleId: httpTransactionIndex
           attributes: responseAttributes
         })
 

--- a/test/fixtures/refract-parse-result-empty-request.json
+++ b/test/fixtures/refract-parse-result-empty-request.json
@@ -25,44 +25,13 @@
                 "title": "Users"
               },
               "attributes": {
-                "href": "/users{?limit}"
+                "href": "/users"
               },
               "content": [
                 {
                   "element": "transition",
                   "meta": {
                     "title": "List Users"
-                  },
-                  "attributes": {
-                    "hrefVariables": {
-                      "element": "hrefVariables",
-                      "content": [
-                        {
-                          "element": "member",
-                          "meta": {
-                            "description": "The maximum number of users to return."
-                          },
-                          "attributes": {
-                            "typeAttributes": [
-                              "optional"
-                            ]
-                          },
-                          "content": {
-                            "key": {
-                              "element": "string",
-                              "content": "limit"
-                            },
-                            "value": {
-                              "element": "number",
-                              "attributes": {
-                                "default": "20"
-                              },
-                              "content": 0
-                            }
-                          }
-                        }
-                      ]
-                    }
                   },
                   "content": [
                     {
@@ -78,40 +47,9 @@
                         {
                           "element": "httpResponse",
                           "attributes": {
-                            "statusCode": "200",
-                            "headers": {
-                              "element": "httpHeaders",
-                              "content": [
-                                {
-                                  "element": "member",
-                                  "content": {
-                                    "key": {
-                                      "element": "string",
-                                      "content": "Content-Type"
-                                    },
-                                    "value": {
-                                      "element": "string",
-                                      "content": "application/json"
-                                    }
-                                  }
-                                }
-                              ]
-                            }
+                            "statusCode": "204"
                           },
-                          "content": [
-                            {
-                              "element": "asset",
-                              "meta": {
-                                "classes": [
-                                  "messageBody"
-                                ]
-                              },
-                              "attributes": {
-                                "contentType": "application/json"
-                              },
-                              "content": "[\n  {\n    \"username\": \"pksunkara\"\n  },\n  {\n    \"username\": \"kylef\"\n  }\n]\n"
-                            }
-                          ]
+                          "content": []
                         }
                       ]
                     },
@@ -124,65 +62,16 @@
                             "title": "Only one user"
                           },
                           "attributes": {
-                            "method": "GET",
-                            "hrefVariables": {
-                              "element": "hrefVariables",
-                              "content": [
-                                {
-                                  "element": "member",
-                                  "content": {
-                                    "key": {
-                                      "element": "string",
-                                      "content": "limit"
-                                    },
-                                    "value": {
-                                      "element": "string",
-                                      "content": "1"
-                                    }
-                                  }
-                                }
-                              ]
-                            }
+                            "method": "GET"
                           },
                           "content": []
                         },
                         {
                           "element": "httpResponse",
                           "attributes": {
-                            "statusCode": "200",
-                            "headers": {
-                              "element": "httpHeaders",
-                              "content": [
-                                {
-                                  "element": "member",
-                                  "content": {
-                                    "key": {
-                                      "element": "string",
-                                      "content": "Content-Type"
-                                    },
-                                    "value": {
-                                      "element": "string",
-                                      "content": "application/json"
-                                    }
-                                  }
-                                }
-                              ]
-                            }
+                            "statusCode": "204"
                           },
-                          "content": [
-                            {
-                              "element": "asset",
-                              "meta": {
-                                "classes": [
-                                  "messageBody"
-                                ]
-                              },
-                              "attributes": {
-                                "contentType": "application/json"
-                              },
-                              "content": "[\n  {\n    \"username\": \"pksunkara\"\n  }\n]\n"
-                            }
-                          ]
+                          "content": []
                         }
                       ]
                     }

--- a/test/fixtures/refract-parse-result-empty-request.json
+++ b/test/fixtures/refract-parse-result-empty-request.json
@@ -1,0 +1,198 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "API name"
+      },
+      "content": [
+        {
+          "element": "category",
+          "meta": {
+            "classes": [
+              "resourceGroup"
+            ],
+            "title": "Users"
+          },
+          "content": [
+            {
+              "element": "resource",
+              "meta": {
+                "title": "Users"
+              },
+              "attributes": {
+                "href": "/users{?limit}"
+              },
+              "content": [
+                {
+                  "element": "transition",
+                  "meta": {
+                    "title": "List Users"
+                  },
+                  "attributes": {
+                    "hrefVariables": {
+                      "element": "hrefVariables",
+                      "content": [
+                        {
+                          "element": "member",
+                          "meta": {
+                            "description": "The maximum number of users to return."
+                          },
+                          "attributes": {
+                            "typeAttributes": [
+                              "optional"
+                            ]
+                          },
+                          "content": {
+                            "key": {
+                              "element": "string",
+                              "content": "limit"
+                            },
+                            "value": {
+                              "element": "number",
+                              "attributes": {
+                                "default": "20"
+                              },
+                              "content": 0
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "content": [
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "attributes": {
+                            "method": "GET"
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "[\n  {\n    \"username\": \"pksunkara\"\n  },\n  {\n    \"username\": \"kylef\"\n  }\n]\n"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "element": "httpTransaction",
+                      "content": [
+                        {
+                          "element": "httpRequest",
+                          "meta": {
+                            "title": "Only one user"
+                          },
+                          "attributes": {
+                            "method": "GET",
+                            "hrefVariables": {
+                              "element": "hrefVariables",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "limit"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "1"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": []
+                        },
+                        {
+                          "element": "httpResponse",
+                          "attributes": {
+                            "statusCode": "200",
+                            "headers": {
+                              "element": "httpHeaders",
+                              "content": [
+                                {
+                                  "element": "member",
+                                  "content": {
+                                    "key": {
+                                      "element": "string",
+                                      "content": "Content-Type"
+                                    },
+                                    "value": {
+                                      "element": "string",
+                                      "content": "application/json"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          "content": [
+                            {
+                              "element": "asset",
+                              "meta": {
+                                "classes": [
+                                  "messageBody"
+                                ]
+                              },
+                              "attributes": {
+                                "contentType": "application/json"
+                              },
+                              "content": "[\n  {\n    \"username\": \"pksunkara\"\n  }\n]\n"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -444,6 +444,7 @@ describe('Transformations • Refract', ->
 
       it('Data Structure is present for HTTP Requests', ->
         dataStructureElement = applicationAst.sections[0].resources[0].requests[0].attributes.element
+        console.log(dataStructureElement)
         assert.strictEqual(dataStructureElement, 'dataStructure')
       )
 
@@ -462,8 +463,32 @@ describe('Transformations • Refract', ->
         )
       )
 
+      it('Has a request', ->
+        assert.isObject(applicationAst.sections[0].resources[0].request)
+      )
+
       it('Has the correct HTTP request', ->
         assert.strictEqual(applicationAst.sections[0].resources[0].requests.length, 1)
+      )
+    )
+
+    describe('Empty request', ->
+      applicationAst = null
+
+      before(->
+        applicationAst = convertToApplicationAst(
+          require('./fixtures/refract-parse-result-empty-request.json')
+        )
+      )
+
+      it('Has a request', ->
+        assert.isObject(applicationAst.sections[0].resources[0].request)
+        assert.strictEqual(applicationAst.sections[0].resources[0].request.name, 'Only one user')
+      )
+
+      it('Has the correct HTTP request', ->
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests.length, 1)
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests[0].name, 'Only one user')
       )
     )
 

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -492,6 +492,27 @@ describe('Transformations • Refract', ->
       )
     )
 
+    describe('Request and Response exampleId', ->
+      applicationAst = null
+
+      before(->
+        applicationAst = convertToApplicationAst(
+          require('./fixtures/refract-parse-result-empty-request.json')
+        )
+      )
+
+      it('has a single request with correct exampleId', ->
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests.length, 1)
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests[0].exampleId, 1)
+      )
+
+      it('has two responses with correct exampleId', ->
+        assert.strictEqual(applicationAst.sections[0].resources[0].responses.length, 2)
+        assert.strictEqual(applicationAst.sections[0].resources[0].responses[0].exampleId, 0)
+        assert.strictEqual(applicationAst.sections[0].resources[0].responses[1].exampleId, 1)
+      )
+    )
+
     describe('‘x-summary’ and ‘x-description’', ->
       applicationAst = null
 

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -444,7 +444,6 @@ describe('Transformations • Refract', ->
 
       it('Data Structure is present for HTTP Requests', ->
         dataStructureElement = applicationAst.sections[0].resources[0].requests[0].attributes.element
-        console.log(dataStructureElement)
         assert.strictEqual(dataStructureElement, 'dataStructure')
       )
 


### PR DESCRIPTION
- Include the request and response exampleId.
- Prevents adding empty requests along side non-empty requests. This fixes a behaviour from the API Blueprint AST where there isn't a requests set when a user didn't provide one. In API Elements, an httpTransaction always has a httpRequest and the method will be included in the httpRequest. In the Refract adapter, we must drop these empty requests to provide the exact same Application AST result for the equivalent Refract document compared to API Blueprint AST. This can be demonstrated with the blueprint found at https://github.com/apiaryio/drafter/blob/master/test/fixtures/api/request-parameters.apib.
