### PR TITLE
Configure coverage reporting with coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ lib
 npm-debug.log
 *.DS_Store
 *.sublime-workspace
+
+coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ npm-debug.log
 *.sublime-*
 test
 karma.conf.js
+coverage/

--- a/circle.yml
+++ b/circle.yml
@@ -7,3 +7,7 @@ dependencies:
     - npm install -g npm@2.15.11
   override:
     - npm install
+
+test:
+  post:
+    - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "lint-update": "curl 'https://raw.githubusercontent.com/apiaryio/coffeescript-style-guide/master/coffeelint.json' > coffeelint.json",
     "precompile": "npm run lint",
     "compile": "coffee -b -c -o lib/ src/",
-    "server-test": "mocha --compilers coffee:coffee-script/register -R spec --recursive --timeout 5000 test/**-test.coffee",
-    "test": "npm run lint && npm run server-test",
+    "test": "npm run lint && mocha",
+    "cover": "istanbul report text-summary lcov",
+    "coveralls": "npm run cover && cat coverage/lcov.info | coveralls",
     "prepublish": "npm run compile"
   },
   "engines": {
@@ -35,10 +36,13 @@
   "devDependencies": {
     "swagger-zoo": "^2.2.1",
     "chai": "^3.2.0",
+    "coffee-coverage": "^1.0.1",
     "coffee-script": "~1.9",
     "coffeeify": "^1.1.0",
     "coffeelint": "^1.11.1",
+    "coveralls": "^2.11.0",
     "protagonist": "^1.6.2",
+    "istanbul": "^0.4.5",
     "mocha": "^2.3.0",
     "sinon": "^1.17.2"
   }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--compilers coffee:coffee-script/register
+--require coffee-coverage/register-istanbul
+--recursive


### PR DESCRIPTION
This PR adds coverage reporting for CoffeeScript and uploads to coveralls after the tests pass in CI. There is now a CI check, which will show the coverage % change during each PR after this one.

<img width="780" alt="screen shot 2016-12-12 at 23 06 05" src="https://cloud.githubusercontent.com/assets/44164/21120508/a2160d9a-c0bf-11e6-9a79-8e8d7ed5ab75.png">
