### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Metamorphoses Changelog
 
-# Master
+# 0.13.0
 
 ## Breaking
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {


### PR DESCRIPTION
## Breaking

- `transformError` now accepts a parse result.
- Removes support for Apiary Blueprint AST. [Fury Apiary Blueprint Parser](https://github.com/apiaryio/fury-adapter-apiary-blueprint-parser) can be used in conjunction with the API Elements adapter in Metamorphoses.