### PR TITLE
Refract transformError: Handle when source maps are missing for an annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Metamorphoses Changelog
 
+# Master
+
+### Bug Fixes
+
+- Fixes Refract adapters `transformError` to handle errors which do not contain
+  a source map.
+
 # 0.13.0
 
 ## Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Metamorphoses Changelog
 
-# Master
+# 0.13.1
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/adapters/refract-adapter.coffee
+++ b/src/adapters/refract-adapter.coffee
@@ -68,7 +68,11 @@ transformError = (source, parseResult) ->
   if errors.length > 0
     errorElement = errors[0]
     sourceMaps = errorElement.attributes?.sourceMap?[0]?.content
-    locations = sourceMaps.map((sourceMap) -> {index: sourceMap[0], length: sourceMap[1]})
+    locations = sourceMaps?.map((sourceMap) -> {index: sourceMap[0], length: sourceMap[1]})
+
+    unless locations
+      # When there is no existing source maps, treat whole document as source
+      locations = [{index: 0, length: source.length}]
 
     error = {
       message: errorElement.content

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -668,6 +668,33 @@ describe('Transformations • Refract', ->
       assert.equal(err.location[1].length, 2)
     )
 
+    it('can transform an error from a parse result with missing source maps', ->
+      parseResult = {
+        element: 'parseResult',
+        content: [
+          {
+            element: 'annotation',
+            meta: {
+              classes: ['error'],
+            },
+            attributes: {
+              code: 10,
+            },
+            content: 'Malformed syntax'
+          }
+        ]
+      }
+
+      err = refractAdapter.transformError('source\n\n\nerror line\n\nerr', parseResult)
+      assert.isDefined(err)
+      assert.equal(err.message, 'Malformed syntax')
+      assert.equal(err.code, 10)
+      assert.equal(err.line, 1)
+      assert.equal(err.location.length, 1)
+      assert.equal(err.location[0].index, 0)
+      assert.equal(err.location[0].length, 24)
+    )
+
     it('does not return an error when there is no error in parse result', ->
       parseResult = {
         element: 'parseResult',


### PR DESCRIPTION
When there is no source map for an error, we will now create the source map for the entire document since we do not know a specific section.

This fixes the problem mentioned at [Trello Tracking Card](https://trello.com/c/02EUWnpR/687-typeerror-cannot-read-property-map-of-undefined).