### PR TITLE
Make sure empty request in refract has the same properties as empty request in AST

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/adapters/refract/transformTransactions.coffee
+++ b/src/adapters/refract/transformTransactions.coffee
@@ -115,6 +115,10 @@ module.exports = (transactions, options) ->
 
   # Add an empty request if no requests exit
   if not requests.length
-    requests.push(new blueprintApi.Request({}))
+    requests.push(new blueprintApi.Request({
+      name: ''
+      description: ''
+      htmlDescription: ''
+    }))
 
   [method, requests, responses]


### PR DESCRIPTION
I have tried to change the original `BlueprintAPI.Request` class and tried to streamline it, but it kept getting more complex and got out of hand. So, I just deleted all that code and added this temporary fix for now. We can clean up some of this stuff once we remove AST.