### PR TITLE
Merge multiple headers with the same key into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Fixes dropped values when there are multiple headers with the same key in the API Blueprint adapter.
+- Fixes dropped values when there are multiple headers with the same key in the API Blueprint and refract adapters.
 
 ## 0.13.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Metamorphoses Changelog
 
+## 0.13.8
+
+### Bug Fixes
+
+- Fixes dropped values when there are multiple headers with the same key in the API Blueprint adapter.
+
 ## 0.13.7
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/adapters/api-blueprint-adapter.coffee
+++ b/src/adapters/api-blueprint-adapter.coffee
@@ -80,7 +80,7 @@ ensureObjectOfObjects = (data, key = 'name') ->
 # is turned into
 #
 #   [
-#     { name: 'Set-Cookie', value: 'abcde; Alan Turing' }
+#     { name: 'Set-Cookie', value: 'abcde, Alan Turing' }
 #   ]
 mergeMultipleHeaders = (headers) ->
   if not headers or not headers.length
@@ -89,7 +89,7 @@ mergeMultipleHeaders = (headers) ->
   mergedHeadersMap = headers.reduce((result, header) ->
     value = null
 
-    if result[header.name] then value = "#{result[header.name]}; #{header.value}"
+    if result[header.name] then value = "#{result[header.name]}, #{header.value}"
     else value = header.value
 
     result[header.name] = value

--- a/src/adapters/refract/getHeaders.coffee
+++ b/src/adapters/refract/getHeaders.coffee
@@ -12,7 +12,8 @@ module.exports = (element) ->
     key = _.chain(content).get('key').contentOrValue().value()
     value = _.chain(content).get('value').contentOrValue().value()
 
-    headers[key] = value if key
+    if headers[key] then headers[key] = "#{headers[key]}; #{value}"
+    else headers[key] = value if key
   )
 
   headers

--- a/src/adapters/refract/getHeaders.coffee
+++ b/src/adapters/refract/getHeaders.coffee
@@ -12,7 +12,7 @@ module.exports = (element) ->
     key = _.chain(content).get('key').contentOrValue().value()
     value = _.chain(content).get('value').contentOrValue().value()
 
-    if headers[key] then headers[key] = "#{headers[key]}; #{value}"
+    if headers[key] then headers[key] = "#{headers[key]}, #{value}"
     else headers[key] = value if key
   )
 

--- a/test/transformation-test.coffee
+++ b/test/transformation-test.coffee
@@ -167,7 +167,7 @@ describe('Transformations', ->
               assert.equal(ast.sections[0].resources[0].responses[0].body, 'Hello World')
           )
           it('response has correctly merged headers', ->
-            assert.equal(ast.sections[0].resources[0].responses[0].headers['Set-Cookie'], 'Yo!; Yo again!; Yo moar!')
+            assert.equal(ast.sections[0].resources[0].responses[0].headers['Set-Cookie'], 'Yo!, Yo again!, Yo moar!')
           )
           if type.match(/source-map/)
             it('resource group has a valid source map', ->
@@ -410,7 +410,7 @@ describe('Transformations', ->
             headers = ast.sections[0].resources[0].responses[0].headers
             assert.equal(headers['Content-Type'], 'application/json')
             assert.equal(headers['X-My-Header'], 'The Value')
-            assert.equal(headers['Set-Cookie'], 'abcd; efgh')
+            assert.equal(headers['Set-Cookie'], 'abcd, efgh')
           )
 
           it('I got parameters right', ->

--- a/test/transformation-test.coffee
+++ b/test/transformation-test.coffee
@@ -401,7 +401,7 @@ describe('Transformations', ->
             headers = ast.sections[0].resources[0].responses[0].headers
             assert.equal(headers['Content-Type'], 'application/json')
             assert.equal(headers['X-My-Header'], 'The Value')
-            assert.equal(headers['Set-Cookie'], 'efgh')
+            assert.equal(headers['Set-Cookie'], 'abcd; efgh')
           )
 
           it('I got parameters right', ->

--- a/test/transformation-test.coffee
+++ b/test/transformation-test.coffee
@@ -96,6 +96,12 @@ describe('Transformations', ->
                    Lorem ipsum 4
 
                    + Response 200 (text/plain)
+                     + Headers
+
+                              Set-Cookie: Yo!
+                              Set-Cookie: Yo again!
+                              Set-Cookie: Yo moar!
+
                      + Body
 
                                Hello World
@@ -159,6 +165,9 @@ describe('Transformations', ->
             # temporary hack before new protagonist with fix for from classes array in messageBody will be relased
             if type isnt 'refract'
               assert.equal(ast.sections[0].resources[0].responses[0].body, 'Hello World')
+          )
+          it('response has correctly merged headers', ->
+            assert.equal(ast.sections[0].resources[0].responses[0].headers['Set-Cookie'], 'Yo!; Yo again!; Yo moar!')
           )
           if type.match(/source-map/)
             it('resource group has a valid source map', ->


### PR DESCRIPTION
This PR fixes issue with dropped header values during A1 -> legacy transformation in API Blueprint and refract adapters.