### PR TITLE
Add headers1A property to the AST for both API Blueprint and Refract adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- `headers1A` property added to the Request / Response transaction pairs for both API Blueprint and Refract adapters.
+- `headers1A` property added to the Request / Response transaction pairs for both API Blueprint and Refract adapters to support multiple headers with the same key / name.
 
 ## 0.13.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Metamorphoses Changelog
 
+## 0.13.8
+
+### Enhancements
+
+- `headers1A` property added to the Request / Response transaction pairs for both API Blueprint and Refract adapters.
+
 ## 0.13.7
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/src/adapters/api-blueprint-adapter.coffee
+++ b/src/adapters/api-blueprint-adapter.coffee
@@ -152,6 +152,8 @@ legacyRequestFrom1ARequest = (request, action, resource, exampleId = undefined, 
     exampleId: exampleId
   )
 
+  legacyRequest.headers1A = request.headers
+
   legacyRequest.description     = trimLastNewline(request.description) or ''
   legacyRequest.htmlDescription = trimLastNewline(markdown.toHtmlSync(request.description, options)) or ''
 
@@ -186,6 +188,8 @@ legacyResponseFrom1AResponse = (response, action, resource, exampleId = undefine
     headers: legacyHeadersCombinedFrom1A(response, action, resource)
     exampleId: exampleId
   )
+
+  legacyResponse.headers1A = response.headers
 
   legacyResponse.description     = trimLastNewline(response.description) or ''
   legacyResponse.htmlDescription = trimLastNewline(markdown.toHtmlSync(response.description, options)) or ''

--- a/src/adapters/refract/getHeaders.coffee
+++ b/src/adapters/refract/getHeaders.coffee
@@ -16,7 +16,7 @@ module.exports = (element) ->
     headers[key] = value if key
 
     headers1A.push({
-      key,
+      name: key
       value
     }) if key
   )

--- a/src/adapters/refract/getHeaders.coffee
+++ b/src/adapters/refract/getHeaders.coffee
@@ -1,24 +1,35 @@
 _ = require('./helper')
 
-module.exports = (element) ->
-  headers = {}
-  headers1A = []
-
+transformHeaders = (element, type) ->
+  result = if type is 'legacy' then {} else []
   httpHeaders = _.get(element, 'attributes.headers')
 
-  return headers if not httpHeaders
+  return result if not httpHeaders
 
   _.content(httpHeaders).forEach((headerElement) ->
     content = _.content(headerElement)
     key = _.chain(content).get('key').contentOrValue().value()
     value = _.chain(content).get('value').contentOrValue().value()
 
-    headers[key] = value if key
-
-    headers1A.push({
-      name: key
-      value
-    }) if key
+    switch type
+      when 'legacy'
+        result[key] = value if key
+      when '1A'
+        result.push({
+          name: key
+          value
+        })
   )
 
-  [headers, headers1A]
+  result
+
+getHeaders = (element) ->
+  transformHeaders(element, 'legacy')
+
+getHeaders1A = (element) ->
+  transformHeaders(element, '1A')
+
+module.exports = {
+  getHeaders
+  getHeaders1A
+}

--- a/src/adapters/refract/getHeaders.coffee
+++ b/src/adapters/refract/getHeaders.coffee
@@ -2,6 +2,7 @@ _ = require('./helper')
 
 module.exports = (element) ->
   headers = {}
+  headers1A = []
 
   httpHeaders = _.get(element, 'attributes.headers')
 
@@ -13,6 +14,11 @@ module.exports = (element) ->
     value = _.chain(content).get('value').contentOrValue().value()
 
     headers[key] = value if key
+
+    headers1A.push({
+      key,
+      value
+    }) if key
   )
 
-  headers
+  [headers, headers1A]

--- a/src/adapters/refract/transformTransactions.coffee
+++ b/src/adapters/refract/transformTransactions.coffee
@@ -1,8 +1,8 @@
 _ = require('./helper')
 blueprintApi = require('../../blueprint-api')
 getDescription = require('./getDescription')
-getHeaders = require('./getHeaders')
 transformAuth = require('./transformAuth')
+{getHeaders, getHeaders1A} = require('./getHeaders')
 
 trimLastNewline = (s) ->
   unless s
@@ -69,7 +69,8 @@ module.exports = (transactions, options) ->
     requestSchema = trimLastNewline(if _.content(httpRequestBodySchemas) then _.content(httpRequestBodySchemas) else '')
     requestAuthSchemes = transformAuth(httpTransaction, options)
 
-    [requestHeaders, requestHeaders1A] = getHeaders(httpRequest)
+    requestHeaders = getHeaders(httpRequest)
+    requestHeaders1A = getHeaders1A(httpRequest)
 
     httpRequestIsEmpty = _.isEmpty(requestName) \
       and _.isEmpty(httpRequestDescription.raw) \
@@ -100,7 +101,8 @@ module.exports = (transactions, options) ->
       prevRequests.push(httpRequest)
 
     if not alreadyUsedResponse and (httpResponse?.content.length or (not _.isEmpty(httpResponse?.attributes)))
-      [httpResponseHeaders, httpResponseHeaders1A] = getHeaders(httpResponse)
+      httpResponseHeaders = getHeaders(httpResponse)
+      httpResponseHeaders1A = getHeaders1A(httpResponse)
 
       response = new blueprintApi.Response({
         status: _.chain(httpResponse).get('attributes.statusCode').contentOrValue().value()

--- a/src/adapters/refract/transformTransactions.coffee
+++ b/src/adapters/refract/transformTransactions.coffee
@@ -65,10 +65,11 @@ module.exports = (transactions, options) ->
 
     # Check for empty http request
     requestName = _.chain(httpRequest).get('meta.title', '').contentOrValue().value()
-    requestHeaders = getHeaders(httpRequest)
     requestBody = trimLastNewline(if _.content(httpRequestBody) then _.content(httpRequestBody) else '')
     requestSchema = trimLastNewline(if _.content(httpRequestBodySchemas) then _.content(httpRequestBodySchemas) else '')
     requestAuthSchemes = transformAuth(httpTransaction, options)
+
+    [requestHeaders, requestHeaders1A] = getHeaders(httpRequest)
 
     httpRequestIsEmpty = _.isEmpty(requestName) \
       and _.isEmpty(httpRequestDescription.raw) \
@@ -87,6 +88,7 @@ module.exports = (transactions, options) ->
         description: httpRequestDescription.raw
         htmlDescription: httpRequestDescription.html
         headers: requestHeaders
+        headers1A: requestHeaders1A
         body: requestBody
         schema: requestSchema
         exampleId: exampleIndex
@@ -98,11 +100,14 @@ module.exports = (transactions, options) ->
       prevRequests.push(httpRequest)
 
     if not alreadyUsedResponse and (httpResponse?.content.length or (not _.isEmpty(httpResponse?.attributes)))
+      [httpResponseHeaders, httpResponseHeaders1A] = getHeaders(httpResponse)
+
       response = new blueprintApi.Response({
         status: _.chain(httpResponse).get('attributes.statusCode').contentOrValue().value()
         description: httpResponseDescription.raw
         htmlDescription: httpResponseDescription.html
-        headers: getHeaders(httpResponse)
+        headers: httpResponseHeaders
+        headers1A: httpResponseHeaders1A
         body: trimLastNewline(if _.content(httpResponseBody) then _.content(httpResponseBody) else '')
         schema: trimLastNewline(if _.content(httpResponseBodySchemas) then _.content(httpResponseBodySchemas) else '')
         exampleId: exampleIndex

--- a/src/blueprint-api.coffee
+++ b/src/blueprint-api.coffee
@@ -305,6 +305,7 @@ class Request
       description: json.description # Markdown description of the request
       htmlDescription: json.htmlDescription # Rendered description of the request
       headers: json.headers
+      headers1A: json.headers1A
       reference: json.reference
       body: json.body
       schema: json.schema
@@ -320,6 +321,7 @@ class Request
       description: undefined
       htmlDescription: undefined
       headers: {}
+      headers1A: []
       reference: undefined
       body: ''
       schema: ''
@@ -334,6 +336,7 @@ class Request
     @description
     @htmlDescription
     @headers
+    @headers1A
     @reference
     @body
     @schema
@@ -361,6 +364,7 @@ class Response
       description: json.description
       htmlDescription: json.htmlDescription
       headers: json.headers
+      headers1A: json.headers1A
       reference: json.reference
       body: json.body
       schema: json.schema
@@ -375,6 +379,7 @@ class Response
       description: undefined
       htmlDescription: undefined
       headers: {}
+      headers1A: []
       reference: undefined
       body: ''
       schema: ''
@@ -388,6 +393,7 @@ class Response
     @description
     @htmlDescription
     @headers
+    @headers1A
     @reference
     @body
     @schema

--- a/test/transformation-test.coffee
+++ b/test/transformation-test.coffee
@@ -96,6 +96,12 @@ describe('Transformations', ->
                    Lorem ipsum 4
 
                    + Response 200 (text/plain)
+                     + Headers
+
+                              Set-Cookie: Yo!
+                              Set-Cookie: Yo again!
+                              Set-Cookie: Yo moar!
+
                      + Body
 
                                Hello World
@@ -159,6 +165,15 @@ describe('Transformations', ->
             # temporary hack before new protagonist with fix for from classes array in messageBody will be relased
             if type isnt 'refract'
               assert.equal(ast.sections[0].resources[0].responses[0].body, 'Hello World')
+          )
+          it('response has headers1A property', ->
+            assert.isDefined(ast.sections[0].resources[0].responses[0].headers1A)
+          )
+          it('response has headers1A with three Set-Cookie headers', ->
+            setCookieHeaders = ast.sections[0].resources[0].responses[0].headers1A.filter((item) ->
+              item.name is 'Set-Cookie'
+            )
+            assert.equal(setCookieHeaders.length, 3)
           )
           if type.match(/source-map/)
             it('resource group has a valid source map', ->

--- a/test/transformation-test.coffee
+++ b/test/transformation-test.coffee
@@ -170,10 +170,16 @@ describe('Transformations', ->
             assert.isDefined(ast.sections[0].resources[0].responses[0].headers1A)
           )
           it('response has headers1A with three Set-Cookie headers', ->
+            expectedValues = ['Yo!', 'Yo again!', 'Yo moar!']
             setCookieHeaders = ast.sections[0].resources[0].responses[0].headers1A.filter((item) ->
               item.name is 'Set-Cookie'
             )
+
             assert.equal(setCookieHeaders.length, 3)
+
+            setCookieHeaders.forEach((item, index) ->
+              assert.equal(item.value, expectedValues[index])
+            )
           )
           if type.match(/source-map/)
             it('resource group has a valid source map', ->


### PR DESCRIPTION
Changes made in this PR are needed for support of multiple headers (with the same key / header name) in the core app.