### PR TITLE
Handle multiple transaction pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Metamorphoses Changelog
 
+## 0.14.0
+
+### BREAKING
+
+- Leading empty requests (defined in API Blueprint just as `+ Request`) are not skipped anymore and will appear in the metamorphoses output.
+
 ## 0.13.8
 
 ### Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apiaryio/metamorphoses",
-  "version": "0.13.8",
+  "version": "0.14.0",
   "description": "Transforms API Blueprint AST or legacy Apiary Blueprint AST into Apiary Application AST",
   "main": "./lib/metamorphoses",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "coffeeify": "^1.1.0",
     "coffeelint": "^1.11.1",
     "coveralls": "^2.11.0",
+    "drafter": "^1.2.0",
     "istanbul": "^0.4.5",
     "mocha": "^2.3.0",
-    "protagonist": "^1.6.4",
+    "protagonist": "^1.6.8",
     "sinon": "^1.17.2",
     "swagger-zoo": "^2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "type": "git",
     "url": "git+ssh://git@github.com:apiaryio/metamorphoses.git"
   },
+  "publishConfig": {
+    "registry": "https://registry.apiary-internal.com"
+  },
   "author": "Apiary Inc <support@apiary.io>",
   "license": "MIT",
   "bugs": {

--- a/src/adapters/refract/transformTransactions.coffee
+++ b/src/adapters/refract/transformTransactions.coffee
@@ -72,18 +72,7 @@ module.exports = (transactions, options) ->
     requestHeaders = getHeaders(httpRequest)
     requestHeaders1A = getHeaders1A(httpRequest)
 
-    httpRequestIsEmpty = _.isEmpty(requestName) \
-      and _.isEmpty(httpRequestDescription.raw) \
-      and _.isEmpty(requestHeaders) \
-      and _.isEmpty(requestBody) \
-      and _.isEmpty(requestSchema) \
-      and _.isEmpty(requestAttributes) \
-      and _.isEmpty(requestAuthSchemes)
-
-    if httpRequestIsEmpty
-      prevRequests.push(httpRequest)
-
-    if not httpRequestIsEmpty and not alreadyUsedRequest
+    if not alreadyUsedRequest
       request = new blueprintApi.Request({
         name: requestName
         description: httpRequestDescription.raw

--- a/test/multiple-transactions-test.coffee
+++ b/test/multiple-transactions-test.coffee
@@ -15,19 +15,19 @@ source = '''
   + Response 200 (application/json)
       + Body
 
-          {"message": "Hello World!"}
+              {"message": "Hello World!"}
 
   + Request User Error
   + Response 400 (application/json)
       + Body
 
-          {"error": "This is error :("}
+              {"error": "This is error :("}
 
   + Request Something Not Found
   + Response 404 (application/json)
       + Body
 
-          {"error": "This is error :("}
+              {"error": "This is error :("}
 '''
 
 

--- a/test/multiple-transactions-test.coffee
+++ b/test/multiple-transactions-test.coffee
@@ -1,0 +1,89 @@
+{assert} = require('chai')
+drafter = require('drafter')
+
+metamorphoses = require('../src/metamorphoses')
+
+
+source = '''
+  FORMAT: 1A
+
+  # Test API
+  ## Test [/test]
+  ### Test Test Test [GET]
+
+  + Request
+  + Response 200 (application/json)
+      + Body
+
+          {"message": "Hello World!"}
+
+  + Request User Error
+  + Response 400 (application/json)
+      + Body
+
+          {"error": "This is error :("}
+
+  + Request Something Not Found
+  + Response 404 (application/json)
+      + Body
+
+          {"error": "This is error :("}
+'''
+
+
+isApiElement = (element) ->
+  return false if element.element isnt 'category'
+  return element.meta?.classes.indexOf('api') isnt -1
+
+
+describe.only('Multiple Transactions', ->
+  describe('when API Blueprint has three request-response pairs', ->
+    applicationAst = undefined
+
+    beforeEach((done) ->
+      mediaType = 'application/vnd.refract.api-description+json'
+      adapter = metamorphoses.createAdapter(mediaType)
+
+      drafter.parse(source, (err, parseResult) ->
+        return done(err) if err
+
+        apiElement = parseResult.content.filter(isApiElement)[0]
+        applicationAst = adapter.transformAst(apiElement)
+        done()
+      )
+    )
+
+    it('produces three requests', ->
+      assert.equal(applicationAst.sections[0].resources[0].requests.length, 3)
+    )
+    it('produces three responses', ->
+      assert.equal(applicationAst.sections[0].resources[0].responses.length, 3)
+    )
+
+    examples = [
+      {reqName: '', resStatusCode: 200}
+      {reqName: 'User Error', resStatusCode: 400}
+      {reqName: 'Something Not Found', resStatusCode: 404}
+    ]
+    examples.forEach((pair, pairNumber) ->
+      context("pair ##{pairNumber}", ->
+        it("has request example ID equal to #{pairNumber}", ->
+          req = applicationAst.sections[0].resources[0].requests[pairNumber]
+          assert.equal(req.exampleId, pairNumber)
+        )
+        it("has response example ID equal to #{pairNumber}", ->
+          res = applicationAst.sections[0].resources[0].responses[pairNumber]
+          assert.equal(res.exampleId, pairNumber)
+        )
+        it("has request name '#{pair.reqName}'", ->
+          req = applicationAst.sections[0].resources[0].requests[pairNumber]
+          assert.equal(req.name, pair.reqName)
+        )
+        it("has response status code '#{pair.resStatusCode}'", ->
+          res = applicationAst.sections[0].resources[0].responses[pairNumber]
+          assert.equal(res.status, pair.resStatusCode)
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
Skipping empty requests causes bad request-response pairing in the Apiary Mock Server. There are probably only legacy reasons why the empty requests are getting skipped and with API Elements we should update.

I assumed the versioning scheme from reading 9c6fc1b890dfa3d4a7e362efebcaea6d2f0d1128.

**BREAKING CHANGE**