### PR TITLE
Restore running all tests on master

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "mocha": "^2.3.0",
     "protagonist": "^1.6.8",
     "sinon": "^1.17.2",
-    "swagger-zoo": "^2.2.1"
+    "swagger-zoo": "2.2.1"
   }
 }

--- a/test/multiple-transactions-test.coffee
+++ b/test/multiple-transactions-test.coffee
@@ -36,7 +36,7 @@ isApiElement = (element) ->
   return element.meta?.classes.indexOf('api') isnt -1
 
 
-describe.only('Multiple Transactions', ->
+describe('Multiple Transactions', ->
   describe('when API Blueprint has three request-response pairs', ->
     applicationAst = undefined
 


### PR DESCRIPTION
@honzajavorek Following up from https://github.com/apiaryio/metamorphoses/pull/84#discussion_r154783990, this PR re-enables the tests that was disabled and fixes some test breakages caused by Swagger Zoo version being updated (as Metamorphoses is tightly coupled to Refract serialisation).

I believe the remaining (3) test failures are caused by #84 and I am not sure if the behaviour introduced in #84 is correct and the tests should be updated. Or if the behaviour from #84 is incorrect and should be altered leaving the tests asis.

So I would like to hand this off to you @honzajavorek to finish up.