### PR TITLE
Restore running all tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "mocha": "^2.3.0",
     "protagonist": "^1.6.8",
     "sinon": "^1.17.2",
-    "swagger-zoo": "^2.2.1"
+    "swagger-zoo": "2.2.1"
   }
 }

--- a/test/multiple-transactions-test.coffee
+++ b/test/multiple-transactions-test.coffee
@@ -36,7 +36,7 @@ isApiElement = (element) ->
   return element.meta?.classes.indexOf('api') isnt -1
 
 
-describe.only('Multiple Transactions', ->
+describe('Multiple Transactions', ->
   describe('when API Blueprint has three request-response pairs', ->
     applicationAst = undefined
 

--- a/test/refract-test.coffee
+++ b/test/refract-test.coffee
@@ -518,12 +518,13 @@ describe('Transformations • Refract', ->
 
       it('Has a request', ->
         assert.isObject(applicationAst.sections[0].resources[0].request)
-        assert.strictEqual(applicationAst.sections[0].resources[0].request.name, 'Only one user')
+        assert.strictEqual(applicationAst.sections[0].resources[0].request.name, '')
       )
 
-      it('Has the correct HTTP request', ->
-        assert.strictEqual(applicationAst.sections[0].resources[0].requests.length, 1)
-        assert.strictEqual(applicationAst.sections[0].resources[0].requests[0].name, 'Only one user')
+      it('Has the correct HTTP requests', ->
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests.length, 2)
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests[0].name, '')
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests[1].name, 'Only one user')
       )
     )
 
@@ -537,8 +538,9 @@ describe('Transformations • Refract', ->
       )
 
       it('has a single request with correct exampleId', ->
-        assert.strictEqual(applicationAst.sections[0].resources[0].requests.length, 1)
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests.length, 2)
         assert.strictEqual(applicationAst.sections[0].resources[0].requests[0].exampleId, 0)
+        assert.strictEqual(applicationAst.sections[0].resources[0].requests[1].exampleId, 0)
       )
 
       it('has two responses with correct exampleId', ->


### PR DESCRIPTION
@honzajavorek Following up from https://github.com/apiaryio/metamorphoses/pull/84#discussion_r154783990, this PR re-enables the tests that was disabled and fixes some test breakages caused by Swagger Zoo version being updated (as Metamorphoses is tightly coupled to Refract serialisation).

I believe the remaining (3) test failures are caused by #84, I have updated the tests to match the behaviour introduced in #84, whether that be correct or not.

/cc @honzajavorek please double check that these test changes in https://github.com/apiaryio/metamorphoses/commit/0296053283272c25ccdfe826ad9223c5fe9d9962 are what you intended.