### PR TITLE
prevent no-content example / empty-array example from throwing null pointers

### DIFF
--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -31,9 +31,12 @@ getUriParameters = (hrefVariables, options) ->
     values = []
 
     if lodash.isArray(defaultValue.value())
-      defaultValue = defaultValue.first().contentOrValue().value()?.toString()
+      if defaultValue.value().length > 0
+        defaultValue = defaultValue.first().contentOrValue().value()?.toString()
+      else
+        defaultValue = []
     else
-      defaultValue = defaultValue.value()?.toString()
+      defaultValue = defaultValue.value()?.toString() or ''
 
     if sampleValues.value()
       example = sampleValues.first().contentOrValue()

--- a/src/adapters/refract/getUriParameters.coffee
+++ b/src/adapters/refract/getUriParameters.coffee
@@ -33,7 +33,7 @@ getUriParameters = (hrefVariables, options) ->
     if lodash.isArray(defaultValue.value())
       defaultValue = defaultValue.first().contentOrValue().value()?.toString()
     else
-      defaultValue = defaultValue.value().toString()
+      defaultValue = defaultValue.value()?.toString()
 
     if sampleValues.value()
       example = sampleValues.first().contentOrValue()
@@ -41,7 +41,7 @@ getUriParameters = (hrefVariables, options) ->
       if lodash.isArray(example.value())
         exampleValue = example.first().contentOrValue().value()?.toString()
       else
-        exampleValue = example.value().toString()
+        exampleValue = example.value()?.toString()
 
     memberContentValueContent = memberContentValue.content()
 

--- a/test/getUriParameters-test.coffee
+++ b/test/getUriParameters-test.coffee
@@ -256,6 +256,7 @@ describe('Transformation • Refract • getUriParameters' , ->
           ]
         }]
       },
+      # Sample and default attributes specify no content, just type
       {
         hrefVariables: {
           'element': 'hrefVariables',
@@ -276,10 +277,10 @@ describe('Transformation • Refract • getUriParameters' , ->
                   'element': 'enum',
                   'attributes': {
                     'samples': {
-                        'element': 'number',
+                      'element': 'number',
                     },
                     'default': {
-                        'element': 'number',
+                      'element': 'number',
                     }
                   },
                   'content': [
@@ -317,6 +318,7 @@ describe('Transformation • Refract • getUriParameters' , ->
           }
         ]
       },
+      # Default attribute's content is empty array
       {
         hrefVariables: {
           'element': 'hrefVariables',

--- a/test/getUriParameters-test.coffee
+++ b/test/getUriParameters-test.coffee
@@ -255,7 +255,130 @@ describe('Transformation • Refract • getUriParameters' , ->
             "open_now"
           ]
         }]
-      }
+      },
+      {
+        hrefVariables: {
+          'element': 'hrefVariables',
+          'content': [
+            {
+              'element': 'member',
+              'attributes': {
+                'typeAttributes': [
+                  'optional'
+                ]
+              },
+              'content': {
+                'key': {
+                  'element': 'string',
+                  'content': 'page'
+                },
+                'value': {
+                  'element': 'enum',
+                  'attributes': {
+                    'samples': {
+                        'element': 'number',
+                    },
+                    'default': {
+                        'element': 'number',
+                    }
+                  },
+                  'content': [
+                    {
+                      'element': 'number',
+                      'content': 1
+                    },
+                    {
+                      'element': 'number',
+                      'content': 2
+                    },
+                    {
+                      'element': 'number',
+                      'content': 3
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        parameters: [
+          {
+            'key': 'page',
+            'description': '',
+            'type': 'enum',
+            'required': false,
+            'default': '',
+            'example': '',
+            'values': [
+                '1',
+                '2',
+                '3'
+            ]
+          }
+        ]
+      },
+      {
+        hrefVariables: {
+          'element': 'hrefVariables',
+          'content': [
+            {
+              'element': 'member',
+              'attributes': {
+                'typeAttributes': [
+                  'optional'
+                ]
+              },
+              'content': {
+                'key': {
+                  'element': 'string',
+                  'content': 'page'
+                },
+                'value': {
+                  'element': 'array',
+                  'attributes': {
+                    'samples': {
+                      'element': 'array',
+                    },
+                    'default': {
+                      'content': [],
+                      'element': 'array',
+                    }
+                  },
+                  'content': [
+                    {
+                      'element': 'number',
+                      'content': 1
+                    },
+                    {
+                      'element': 'number',
+                      'content': 2
+                    },
+                    {
+                      'element': 'number',
+                      'content': 3
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        parameters: [
+          {
+            'key': 'page',
+            'description': '',
+            'type': 'array',
+            'required': false,
+            'default': [],
+            'example': '',
+            'values': [
+                '1',
+                '2',
+                '3'
+            ]
+          }
+        ]
+      },
     ]
 
     it('should be transformed into a `parameter` object', ->


### PR DESCRIPTION
this is just a suggestion on what to do with it; if this is the right way to go, it might make sense to also use this for the `example` values